### PR TITLE
Add mock game session

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.10)
+project(cavoke)
+
+add_subdirectory(client)
+add_subdirectory(server)

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -9,6 +9,6 @@ find_package(Boost 1.71 REQUIRED filesystem)
 include_directories(${Boost_INCLUDE_DIRS})
 link_directories(${Boost_LIBRARY_DIRS})
 
-add_executable(cavoke_server model/games_storage.cpp model/game.cpp controllers/games_controller.cpp main.cpp controllers/health_controller.cpp controllers/health_controller.h)
+add_executable(cavoke_server model/games_storage.cpp model/game.cpp controllers/games_controller.cpp main.cpp controllers/health_controller.cpp controllers/health_controller.h model/game_state_storage.cpp model/game_state_storage.h model/participation_storage.cpp model/participation_storage.h model/game_logic_manager.cpp model/game_logic_manager.h model/mock_tictactoe/tictactoe.cpp model/mock_tictactoe/tictactoe.h)
 target_link_libraries(cavoke_server Drogon::Drogon)
 target_link_libraries(cavoke_server ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -9,6 +9,6 @@ find_package(Boost 1.71 REQUIRED filesystem)
 include_directories(${Boost_INCLUDE_DIRS})
 link_directories(${Boost_LIBRARY_DIRS})
 
-add_executable(cavoke_server model/games_storage.cpp model/game.cpp controllers/games_controller.cpp main.cpp controllers/health_controller.cpp controllers/health_controller.h model/game_state_storage.cpp model/game_state_storage.h model/participation_storage.cpp model/participation_storage.h model/game_logic_manager.cpp model/game_logic_manager.h model/mock_tictactoe/tictactoe.cpp model/mock_tictactoe/tictactoe.h controllers/state_controller.cpp controllers/state_controller.h)
+add_executable(cavoke_server model/games_storage.cpp model/game.cpp controllers/games_controller.cpp main.cpp controllers/health_controller.cpp model/game_state_storage.cpp model/participation_storage.cpp model/game_logic_manager.cpp model/mock_tictactoe/tictactoe.cpp controllers/state_controller.cpp)
 target_link_libraries(cavoke_server Drogon::Drogon)
 target_link_libraries(cavoke_server ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -9,6 +9,6 @@ find_package(Boost 1.71 REQUIRED filesystem)
 include_directories(${Boost_INCLUDE_DIRS})
 link_directories(${Boost_LIBRARY_DIRS})
 
-add_executable(cavoke_server model/games_storage.cpp model/game.cpp controllers/games_controller.cpp main.cpp controllers/health_controller.cpp controllers/health_controller.h model/game_state_storage.cpp model/game_state_storage.h model/participation_storage.cpp model/participation_storage.h model/game_logic_manager.cpp model/game_logic_manager.h model/mock_tictactoe/tictactoe.cpp model/mock_tictactoe/tictactoe.h)
+add_executable(cavoke_server model/games_storage.cpp model/game.cpp controllers/games_controller.cpp main.cpp controllers/health_controller.cpp controllers/health_controller.h model/game_state_storage.cpp model/game_state_storage.h model/participation_storage.cpp model/participation_storage.h model/game_logic_manager.cpp model/game_logic_manager.h model/mock_tictactoe/tictactoe.cpp model/mock_tictactoe/tictactoe.h controllers/state_controller.cpp controllers/state_controller.h)
 target_link_libraries(cavoke_server Drogon::Drogon)
 target_link_libraries(cavoke_server ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})

--- a/server/controllers/health_controller.cpp
+++ b/server/controllers/health_controller.cpp
@@ -1,4 +1,5 @@
 #include "health_controller.h"
+
 void cavoke::server::controllers::HealthController::health(
     const drogon::HttpRequestPtr &req,
     std::function<void(const drogon::HttpResponsePtr &)> &&callback) {

--- a/server/controllers/state_controller.cpp
+++ b/server/controllers/state_controller.cpp
@@ -1,0 +1,97 @@
+#include "state_controller.h"
+
+#include <utility>
+
+void cavoke::server::controllers::StateController::send_move(
+    const drogon::HttpRequestPtr &req,
+    std::function<void(const drogon::HttpResponsePtr &)> &&callback,
+    const std::string &session_id) {
+
+  std::optional<std::string> user_id =
+      req->getOptionalParameter<std::string>("user_id");
+
+  if (!user_id.has_value()) {
+    auto resp = drogon::HttpResponse::newHttpResponse();
+    resp->setStatusCode(drogon::HttpStatusCode::k400BadRequest);
+    callback(resp);
+    return;
+  }
+
+  std::optional<int> participant_id =
+      m_participation_storage->get_participant_id(session_id, user_id.value());
+
+  if (!participant_id.has_value()) {
+    auto resp = drogon::HttpResponse::newHttpResponse();
+    resp->setStatusCode(drogon::HttpStatusCode::k403Forbidden);
+    callback(resp);
+    return;
+  }
+
+  std::optional<model::GameStateStorage::GameState> current_state =
+      m_game_state_storage->get_state(session_id);
+
+  if (!current_state.has_value()) {
+    // new session
+    current_state =
+        m_game_logic_manager->send_update("tictactoe", {-1, "", ""});
+  }
+
+  current_state = m_game_logic_manager->send_update(
+      "tictactoe", {participant_id.value(), std::string(req->getBody()),
+                    current_state->global_state});
+
+  m_game_state_storage->save_state(session_id, current_state.value());
+
+  auto resp = drogon::HttpResponse::newHttpResponse();
+  resp->setStatusCode(drogon::HttpStatusCode::k200OK);
+  callback(resp);
+}
+
+void cavoke::server::controllers::StateController::get_update(
+    const drogon::HttpRequestPtr &req,
+    std::function<void(const drogon::HttpResponsePtr &)> &&callback,
+    const std::string &session_id) {
+
+  std::optional<std::string> user_id =
+      req->getOptionalParameter<std::string>("user_id");
+
+  if (!user_id.has_value()) {
+    auto resp = drogon::HttpResponse::newHttpResponse();
+    resp->setStatusCode(drogon::HttpStatusCode::k400BadRequest);
+    callback(resp);
+    return;
+  }
+
+  std::optional<int> participant_id =
+      m_participation_storage->get_participant_id(session_id, user_id.value());
+
+  if (!participant_id.has_value()) {
+    auto resp = drogon::HttpResponse::newHttpResponse();
+    resp->setStatusCode(drogon::HttpStatusCode::k403Forbidden);
+    callback(resp);
+    return;
+  }
+
+  auto state = m_game_state_storage->get_player_state(session_id,
+                                                      participant_id.value());
+
+  if (!state.has_value()) {
+    auto resp = drogon::HttpResponse::newNotFoundResponse();
+    callback(resp);
+    return;
+  }
+
+  auto resp = drogon::HttpResponse::newHttpResponse();
+  resp->setStatusCode(drogon::HttpStatusCode::k200OK);
+  resp->setBody(state.value());
+  callback(resp);
+}
+cavoke::server::controllers::StateController::StateController(
+    std::shared_ptr<model::GamesStorage> mGamesStorage,
+    std::shared_ptr<model::GameLogicManager> mGameLogicManager,
+    std::shared_ptr<model::GameStateStorage> mGameStateStorage,
+    std::shared_ptr<model::ParticipationStorage> mParticipationStorage)
+    : m_games_storage(std::move(mGamesStorage)),
+      m_game_logic_manager(std::move(mGameLogicManager)),
+      m_game_state_storage(std::move(mGameStateStorage)),
+      m_participation_storage(std::move(mParticipationStorage)) {}

--- a/server/controllers/state_controller.h
+++ b/server/controllers/state_controller.h
@@ -1,0 +1,46 @@
+#ifndef CAVOKE_STATE_CONTROLLER_H
+#define CAVOKE_STATE_CONTROLLER_H
+
+#include "../model/game_logic_manager.h"
+#include "../model/games_storage.h"
+#include "../model/participation_storage.h"
+#include <drogon/HttpController.h>
+
+namespace cavoke::server::controllers {
+
+class StateController : public drogon::HttpController<StateController, false> {
+  std::shared_ptr<model::GamesStorage> m_games_storage;
+  std::shared_ptr<model::GameLogicManager> m_game_logic_manager;
+  std::shared_ptr<model::GameStateStorage> m_game_state_storage;
+  std::shared_ptr<model::ParticipationStorage> m_participation_storage;
+
+public:
+  StateController(
+      std::shared_ptr<model::GamesStorage> mGamesStorage,
+      std::shared_ptr<model::GameLogicManager> mGameLogicManager,
+      std::shared_ptr<model::GameStateStorage> mGameStateStorage,
+      std::shared_ptr<model::ParticipationStorage> mParticipationStorage);
+
+public:
+  METHOD_LIST_BEGIN
+  ADD_METHOD_TO(StateController::send_move, "/play/{session_id}/send_move",
+                drogon::Post);
+  ADD_METHOD_TO(StateController::get_update, "/play/{session_id}/get_update",
+                drogon::Get);
+  METHOD_LIST_END
+
+protected:
+  void
+  send_move(const drogon::HttpRequestPtr &req,
+            std::function<void(const drogon::HttpResponsePtr &)> &&callback,
+            const std::string &session_id);
+
+  void
+  get_update(const drogon::HttpRequestPtr &req,
+             std::function<void(const drogon::HttpResponsePtr &)> &&callback,
+             const std::string &session_id);
+};
+
+} // namespace cavoke::server::controllers
+
+#endif // CAVOKE_STATE_CONTROLLER_H

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -1,5 +1,8 @@
 #include "controllers/games_controller.h"
+#include "controllers/state_controller.h"
+#include "model/game_logic_manager.h"
 #include "model/games_storage.h"
+#include "model/participation_storage.h"
 #include <drogon/HttpAppFramework.h>
 
 namespace cavoke::server {
@@ -10,14 +13,22 @@ void run() {
   std::cout << "Initialize models..." << std::endl;
   auto games_storage = std::make_shared<model::GamesStorage>(
       model::GamesStorage::GamesStorageConfig{"../../local_server/games"});
+  auto game_logic_manager =
+      std::make_shared<model::GameLogicManager>(games_storage);
+  auto game_state_storage = std::make_shared<model::GameStateStorage>();
+  auto participation_storage = std::make_shared<model::ParticipationStorage>();
 
   // init controllers
   std::cout << "Initialize controllers..." << std::endl;
   auto games_controller =
       std::make_shared<controllers::GamesController>(games_storage);
+  auto state_controller = std::make_shared<controllers::StateController>(
+      games_storage, game_logic_manager, game_state_storage,
+      participation_storage);
 
   // register controllers
   drogon::app().registerController(games_controller);
+  drogon::app().registerController(state_controller);
 
   // RUN!
   std::cout << "Run server on 127.0.0.1:8080" << std::endl;

--- a/server/model/game_logic_manager.cpp
+++ b/server/model/game_logic_manager.cpp
@@ -13,13 +13,13 @@ GameLogicManager::send_update(const std::string &game_id,
                               const GameLogicManager::GameUpdate &update) {
   // TODO: invoke actual logic
   GameStateStorage::GameState result = GameStateStorage::parse_state(
-      tictactoe::apply(update.to_json().asString()));
+      tictactoe::apply(update.to_json().toStyledString()));
   return result;
 }
 
 Json::Value GameLogicManager::GameUpdate::to_json() const {
   Json::Value result;
-  result["id"] = player_id;
+  result["player_id"] = player_id;
   result["update"] = update;
   result["global_state"] = global_state;
 

--- a/server/model/game_logic_manager.cpp
+++ b/server/model/game_logic_manager.cpp
@@ -1,0 +1,28 @@
+#include "game_logic_manager.h"
+#include "mock_tictactoe/tictactoe.h"
+
+#include <utility>
+
+namespace cavoke::server::model {
+
+GameLogicManager::GameLogicManager(std::shared_ptr<GamesStorage> games_storage)
+    : m_games_storage(std::move(games_storage)) {}
+
+GameStateStorage::GameState
+GameLogicManager::send_update(const std::string &game_id,
+                              const GameLogicManager::GameUpdate &update) {
+  // TODO: invoke actual logic
+  GameStateStorage::GameState result = GameStateStorage::parse_state(
+      tictactoe::apply(update.to_json().asString()));
+  return result;
+}
+
+Json::Value GameLogicManager::GameUpdate::to_json() const {
+  Json::Value result;
+  result["id"] = player_id;
+  result["update"] = update;
+  result["global_state"] = global_state;
+
+  return result;
+}
+} // namespace cavoke::server::model

--- a/server/model/game_logic_manager.h
+++ b/server/model/game_logic_manager.h
@@ -1,0 +1,32 @@
+#ifndef CAVOKE_SERVER_GAME_LOGIC_MANAGER_H
+#define CAVOKE_SERVER_GAME_LOGIC_MANAGER_H
+
+#include "game_state_storage.h"
+#include "games_storage.h"
+#include <memory>
+#include <string>
+
+namespace cavoke::server::model {
+
+class GameLogicManager {
+  std::shared_ptr<GamesStorage> m_games_storage;
+
+public:
+  explicit GameLogicManager(std::shared_ptr<GamesStorage> games_storage);
+
+  struct GameUpdate {
+    int player_id;
+    std::string update;
+    std::string global_state;
+
+
+    [[nodiscard]] Json::Value to_json() const;
+  };
+
+  GameStateStorage::GameState send_update(const std::string& game_id,
+                                          const GameUpdate& update);
+};
+
+} // namespace cavoke::server::model
+
+#endif // CAVOKE_SERVER_GAME_LOGIC_MANAGER_H

--- a/server/model/game_logic_manager.h
+++ b/server/model/game_logic_manager.h
@@ -19,12 +19,11 @@ public:
     std::string update;
     std::string global_state;
 
-
     [[nodiscard]] Json::Value to_json() const;
   };
 
-  GameStateStorage::GameState send_update(const std::string& game_id,
-                                          const GameUpdate& update);
+  GameStateStorage::GameState send_update(const std::string &game_id,
+                                          const GameUpdate &update);
 };
 
 } // namespace cavoke::server::model

--- a/server/model/game_state_storage.cpp
+++ b/server/model/game_state_storage.cpp
@@ -1,0 +1,39 @@
+#include "game_state_storage.h"
+
+#include <json/reader.h>
+#include <utility>
+
+namespace cavoke::server::model {
+
+void GameStateStorage::save_state(const std::string &session_id,
+                                  GameStateStorage::GameState new_state) {
+  m_states[session_id] = std::move(new_state);
+}
+
+std::optional<GameStateStorage::GameState>
+GameStateStorage::get_state(const std::string &session_id) {
+  if (m_states.count(session_id) == 0) {
+    return {};
+  }
+  return m_states[session_id];
+}
+
+GameStateStorage::GameState
+GameStateStorage::parse_state(const std::string &s) {
+  GameState state;
+  Json::Value json_state;
+  Json::Reader reader;
+  reader.parse(s, json_state, false);
+  state.is_terminal = json_state["is_terminal"].asBool();
+  state.global_state = json_state["global_state"].asString();
+  for (Json::Value::ArrayIndex i = 0; i != json_state["players_state"].size();
+       i++) {
+    state.players_state.push_back(json_state["players_state"][i].asString());
+  }
+  for (Json::Value::ArrayIndex i = 0; i != json_state["winners"].size(); i++) {
+    state.winners.push_back(json_state["winners"][i].asInt());
+  }
+  return state;
+}
+
+} // namespace cavoke::server::model

--- a/server/model/game_state_storage.cpp
+++ b/server/model/game_state_storage.cpp
@@ -36,4 +36,17 @@ GameStateStorage::parse_state(const std::string &s) {
   return state;
 }
 
+std::optional<std::string>
+GameStateStorage::get_player_state(const std::string &session_id,
+                                   int player_id) {
+  auto state = get_state(session_id);
+  if (!state.has_value()) {
+    return {};
+  }
+  if (player_id >= state->players_state.size()) {
+    return {};
+  }
+  return state->players_state[player_id];
+}
+
 } // namespace cavoke::server::model

--- a/server/model/game_state_storage.h
+++ b/server/model/game_state_storage.h
@@ -19,7 +19,10 @@ public:
   static GameState parse_state(const std::string &s);
 
   void save_state(const std::string &session_id, GameState new_state);
+
   std::optional<GameState> get_state(const std::string &session_id);
+
+  std::optional<std::string> get_player_state(const std::string &session_id, int player_id);
 
 private:
   std::map<std::string, GameState> m_states;

--- a/server/model/game_state_storage.h
+++ b/server/model/game_state_storage.h
@@ -2,6 +2,7 @@
 #define CAVOKE_SERVER_GAME_STATE_STORAGE_H
 
 #include <map>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -22,7 +23,8 @@ public:
 
   std::optional<GameState> get_state(const std::string &session_id);
 
-  std::optional<std::string> get_player_state(const std::string &session_id, int player_id);
+  std::optional<std::string> get_player_state(const std::string &session_id,
+                                              int player_id);
 
 private:
   std::map<std::string, GameState> m_states;

--- a/server/model/game_state_storage.h
+++ b/server/model/game_state_storage.h
@@ -1,0 +1,30 @@
+#ifndef CAVOKE_SERVER_GAME_STATE_STORAGE_H
+#define CAVOKE_SERVER_GAME_STATE_STORAGE_H
+
+#include <map>
+#include <string>
+#include <vector>
+
+namespace cavoke::server::model {
+
+class GameStateStorage { // TODO: thread safety
+public:
+  struct GameState {
+    bool is_terminal;
+    std::string global_state;
+    std::vector<std::string> players_state;
+    std::vector<int> winners;
+  };
+
+  static GameState parse_state(const std::string &s);
+
+  void save_state(const std::string &session_id, GameState new_state);
+  std::optional<GameState> get_state(const std::string &session_id);
+
+private:
+  std::map<std::string, GameState> m_states;
+};
+
+} // namespace cavoke::server::model
+
+#endif // CAVOKE_SERVER_GAME_STATE_STORAGE_H

--- a/server/model/games_storage.h
+++ b/server/model/games_storage.h
@@ -5,6 +5,7 @@
 #include <boost/filesystem/path.hpp>
 #include <drogon/drogon.h>
 #include <string>
+
 namespace cavoke::server::model {
 
 class GamesStorage {
@@ -20,7 +21,7 @@ public:
 
   std::vector<Game> list_games();
 
-  std::optional<Game> get_game_by_id(const std::string& game_id);
+  std::optional<Game> get_game_by_id(const std::string &game_id);
 
 private:
   GamesStorageConfig m_config;

--- a/server/model/mock_tictactoe/tictactoe.cpp
+++ b/server/model/mock_tictactoe/tictactoe.cpp
@@ -3,6 +3,7 @@
 #include <json/reader.h>
 #include <random>
 #include <sstream>
+#include <iostream>
 
 namespace tictactoe {
 
@@ -63,6 +64,8 @@ void randomAI(std::string &board) {
 }
 
 std::string apply(const std::string &request) {
+  // TODO: logging
+  std::cout << "RECEIVED MOVE " << request << std::endl;
   Json::Reader reader;
   Json::Value json_request;
   reader.parse(request, json_request, false);
@@ -85,15 +88,19 @@ std::string apply(const std::string &request) {
     if (action != 'D') {
       int pos;
       to_split >> pos;
-      makeMove(pos, 'X', board);
-      if (winner(board)) {
-        message = "X wins";
-        restartGame(board);
+      if (!(pos >= 0 && pos < 9 && canPlayAtPos(pos, board))) {
+        message= "Invalid action";
       } else {
-        randomAI(board);
+        makeMove(pos, 'X', board);
         if (winner(board)) {
-          message = "O wins";
+          message = "X wins";
           restartGame(board);
+        } else {
+          randomAI(board);
+          if (winner(board)) {
+            message = "O wins";
+            restartGame(board);
+          }
         }
       }
     }
@@ -107,7 +114,7 @@ std::string apply(const std::string &request) {
   json_result["players_state"].append(board);
   json_result["winners"] = Json::arrayValue;
 
-  return json_result.asString();
+  return json_result.toStyledString();
 }
 
 } // namespace tictactoe

--- a/server/model/mock_tictactoe/tictactoe.cpp
+++ b/server/model/mock_tictactoe/tictactoe.cpp
@@ -1,0 +1,113 @@
+#include "tictactoe.h"
+#include <cmath>
+#include <json/reader.h>
+#include <random>
+#include <sstream>
+
+namespace tictactoe {
+
+std::mt19937 gen;
+std::uniform_real_distribution<> dis;
+
+bool winner(std::string board) {
+  for (int i = 0; i < 3; ++i) {
+    if (board[i] != ' ' && board[i] == board[i + 3] && board[i] == board[i + 6])
+      return true;
+
+    if (board[i * 3] != ' ' && board[i * 3] == board[i * 3 + 1] &&
+        board[i * 3] == board[i * 3 + 2])
+      return true;
+  }
+
+  if (board[0] != ' ' && board[0] == board[4] && board[0] == board[8])
+    return true;
+
+  if (board[2] != ' ' && board[2] == board[4] && board[2] == board[6])
+    return true;
+
+  return false;
+}
+
+bool makeMove(int pos, char player, std::string &board) {
+  board[pos] = player;
+  if (winner(board)) {
+    // gameFinished(player + " wins")
+    return true;
+  }
+  return false;
+}
+
+void restartGame(std::string &board) {
+  for (int i = 0; i < 9; ++i) {
+    board[i] = ' ';
+  }
+}
+
+bool canPlayAtPos(int pos, std::string &board) { return board[pos] == ' '; }
+
+void randomAI(std::string &board) {
+  std::vector<int> unfilledPosns;
+
+  for (int i = 0; i < 9; ++i) {
+    if (canPlayAtPos(i, board)) {
+      unfilledPosns.emplace_back(i);
+    }
+  }
+
+  if (unfilledPosns.empty()) {
+    restartGame(board);
+  } else {
+    int choice = unfilledPosns[std::floor(dis(gen) * unfilledPosns.size())];
+    makeMove(choice, 'O', board);
+  }
+}
+
+std::string apply(const std::string &request) {
+  Json::Reader reader;
+  Json::Value json_request;
+  reader.parse(request, json_request, false);
+  std::string board = json_request["global_state"].asString();
+  std::string update = json_request["update"].asString();
+  int player_id = json_request["player_id"].asInt();
+
+  std::string new_global_state;
+  std::string new_player_state;
+
+  std::string message = "...";
+
+  // player_id == -1 -> start new game
+  if (player_id == -1) {
+    board = std::string(9, ' ');
+  } else {
+    std::stringstream to_split(update);
+    char action;
+    to_split >> action;
+    if (action != 'D') {
+      int pos;
+      to_split >> pos;
+      makeMove(pos, 'X', board);
+      if (winner(board)) {
+        message = "X wins";
+        restartGame(board);
+      } else {
+        randomAI(board);
+        if (winner(board)) {
+          message = "O wins";
+          restartGame(board);
+        }
+      }
+    }
+  }
+
+  std::string new_state = message + "\n" + board;
+
+  Json::Value json_result;
+  json_result["is_terminal"] = false;
+  json_result["global_state"] = board;
+  json_result["players_state"].append(board);
+  json_result["winners"] = Json::arrayValue;
+
+  return json_result.asString();
+}
+
+} // namespace tictactoe

--- a/server/model/mock_tictactoe/tictactoe.h
+++ b/server/model/mock_tictactoe/tictactoe.h
@@ -1,0 +1,12 @@
+#ifndef CAVOKE_TICTACTOE_H
+#define CAVOKE_TICTACTOE_H
+
+#include <string>
+
+namespace tictactoe {
+
+std::string apply(const std::string &request);
+
+}
+
+#endif // CAVOKE_TICTACTOE_H

--- a/server/model/participation_storage.cpp
+++ b/server/model/participation_storage.cpp
@@ -1,0 +1,10 @@
+#include "participation_storage.h"
+
+cavoke::server::model::ParticipationStorage::ParticipationStorage() {}
+
+std::optional<int>
+cavoke::server::model::ParticipationStorage::get_participant_id(
+    const std::string &session_id, const std::string &user_id) {
+  // TODO
+  return 0;
+}

--- a/server/model/participation_storage.h
+++ b/server/model/participation_storage.h
@@ -1,0 +1,21 @@
+#ifndef CAVOKE_SERVER_PARTICIPATION_STORAGE_H
+#define CAVOKE_SERVER_PARTICIPATION_STORAGE_H
+
+#include <optional>
+#include <string>
+namespace cavoke::server::model {
+
+class ParticipationStorage {
+  // TODO: thread-safety
+
+public:
+  ParticipationStorage();
+
+  std::optional<int> get_participant_id(const std::string& session_id,
+                                        const std::string& user_id);
+
+};
+
+} // namespace cavoke::server::model
+
+#endif // CAVOKE_SERVER_PARTICIPATION_STORAGE_H


### PR DESCRIPTION
Поддерживаются

POST /play/{session_id}/send_move{?user_id}
GET /play/{session_id}/get_update{?user_id}

session_id и user_id можно ставить любыми, но обязательно нужно задавать

Ошибки в формате json пока не поддерживаются

В крестиках ноликах в теле POST запроса нужно передавать команды по типу "X 0"

Сами крестики-нолики урезаны -- нет сложностей, нет сообщений (т. к. send_move ничего не возвращает). На будущее, нужно включить сообщения в состояние, либо клиент сам должен понимать, когда что показывать.