### PR TITLE
feature/client-game-logic-prototype

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -22,7 +22,7 @@ include_directories(${CMAKE_BINARY_DIR}
 # https://api.kde.org/frameworks-api/frameworks-apidocs/frameworks/karchive/html/index.html
 find_package(KF5Archive REQUIRED)
 
-add_compile_definitions(MOCK)
+#add_compile_definitions(MOCK)
 
 add_executable(cavoke_client
         main.cpp

--- a/client/controllers/cavokeclientcontroller.cpp
+++ b/client/controllers/cavokeclientcontroller.cpp
@@ -117,7 +117,7 @@ void CavokeClientController::startTicTacToe() {
     currentQmlTimer->callOnTimeout([this]() {
         networkManager.getUpdate(currentQmlGameModel->session_id.toString(), currentQmlGameModel->user_id.toString());
     });
-//    currentQmlTimer->start();
+    currentQmlTimer->start();
 }
 
 void CavokeClientController::stopTicTacToe() {

--- a/client/controllers/cavokeclientcontroller.cpp
+++ b/client/controllers/cavokeclientcontroller.cpp
@@ -106,7 +106,7 @@ void CavokeClientController::exitApplication() {
 }
 void CavokeClientController::startTicTacToe() {
     currentQmlGameModel =
-        new CavokeQmlGameModel(QUrl("/home/mark/CLionProjects/cavoke/client/"
+        new CavokeQmlGameModel(QUrl("../../client/"
                                     "tictactoe-files/tic-tac-toe.qml"));
     startQmlApplication(currentQmlGameModel);
     connect(currentQmlGameModel, SIGNAL(sendMoveToNetwork(QString)),
@@ -122,5 +122,4 @@ void CavokeClientController::stopTicTacToe() {
     startView.show();
     currentQmlGameModel->deleteLater();
     networkManager.stopPolling();
-    //    currentQmlTimer->deleteLater();
 }

--- a/client/controllers/cavokeclientcontroller.h
+++ b/client/controllers/cavokeclientcontroller.h
@@ -41,8 +41,7 @@ private:
     JoinGameView joinGameView;
     CreateGameView createGameView;
     SettingsView settingsView;
-    CavokeQmlGameModel *currentQmlGameModel;
-    QTimer *currentQmlTimer;
+    CavokeQmlGameModel *currentQmlGameModel = nullptr;
 };
 
 #endif // CAVOKECLIENTCONTROLLER_H

--- a/client/controllers/cavokeclientcontroller.h
+++ b/client/controllers/cavokeclientcontroller.h
@@ -31,6 +31,8 @@ signals:
 private slots:
     void startQmlApplication(CavokeQmlGameModel*);
     void exitApplication();
+    void startTicTacToe();
+    void stopTicTacToe();
 private:
     NetworkManager networkManager;
     CavokeClientModel model;
@@ -39,6 +41,8 @@ private:
     JoinGameView joinGameView;
     CreateGameView createGameView;
     SettingsView settingsView;
+    CavokeQmlGameModel *currentQmlGameModel;
+    QTimer *currentQmlTimer;
 };
 
 #endif // CAVOKECLIENTCONTROLLER_H

--- a/client/models/cavokeqmlgamemodel.cpp
+++ b/client/models/cavokeqmlgamemodel.cpp
@@ -5,17 +5,20 @@
 CavokeQmlGameModel::CavokeQmlGameModel(QUrl qmlPath, QObject *parent)
     : QObject{parent}, qmlPath{qmlPath} {  // TODO: std::move
     logic.restartGame();
-    session_id = QUuid::createUuid();
-    user_id = QUuid::createUuid();
 }
 
 void CavokeQmlGameModel::getMoveFromQml(const QString &jsonMove) {
     qDebug() << "CQGM: Received move! " << jsonMove;
     // Maybe we should draw move on board even without network result?
-    emit sendMoveToNetwork(jsonMove, session_id.toString(), user_id.toString());
+    emit sendMoveToNetwork(jsonMove);
 }
 
 void CavokeQmlGameModel::getUpdateFromNetwork(const QString &jsonUpdate) {
     qDebug() << "CQGM: Received update! " << jsonUpdate;
     emit receiveUpdate(jsonUpdate);
+}
+
+void CavokeQmlGameModel::getClosingFromQml(QQuickCloseEvent *close) {
+    qDebug() << "CQGM: Closing!! ";
+    emit closingQml();
 }

--- a/client/models/cavokeqmlgamemodel.cpp
+++ b/client/models/cavokeqmlgamemodel.cpp
@@ -5,17 +5,17 @@
 CavokeQmlGameModel::CavokeQmlGameModel(QUrl qmlPath, QObject *parent)
     : QObject{parent}, qmlPath{qmlPath} {  // TODO: std::move
     logic.restartGame();
+    session_id = QUuid::createUuid();
+    user_id = QUuid::createUuid();
 }
 
-void CavokeQmlGameModel::sendMove(const QString &jsonMove) {
-    // FIXME: Replace with JSON
-    qDebug() << "c++: Received! " << jsonMove;
-    QString processing_result = logic.processAction(jsonMove);
-    QString board = logic.get_board_as_string();
-    
-    if (!logic.running) {       // FIXME: should be moved into logic part
-        logic.restartGame();
-    }
-    QString result = processing_result + "\n" + board;
-    emit receiveUpdate(result);
+void CavokeQmlGameModel::getMoveFromQml(const QString &jsonMove) {
+    qDebug() << "CQGM: Received move! " << jsonMove;
+    // Maybe we should draw move on board even without network result?
+    emit sendMoveToNetwork(jsonMove, session_id.toString(), user_id.toString());
+}
+
+void CavokeQmlGameModel::getUpdateFromNetwork(const QString &jsonUpdate) {
+    qDebug() << "CQGM: Received update! " << jsonUpdate;
+    emit receiveUpdate(jsonUpdate);
 }

--- a/client/models/cavokeqmlgamemodel.h
+++ b/client/models/cavokeqmlgamemodel.h
@@ -4,22 +4,30 @@
 #include <QDebug>
 #include <QObject>
 #include <QUrl>
+#include <QtCore/QUuid>
 #include "tictactoelogic.h"
 
-class CavokeQmlGameModel : public QObject
-{
+class CavokeQmlGameModel : public QObject {
     Q_OBJECT
     tictactoe::tictactoelogic logic{};
+
 public:
     explicit CavokeQmlGameModel(QUrl qmlPath, QObject *parent = nullptr);
 
+public slots:
+    void getMoveFromQml(const QString &jsonMove);
+    void getUpdateFromNetwork(const QString &jsonUpdate);
+
 signals:
     void receiveUpdate(QString jsonUpdate);
-public slots:
-    void sendMove(const QString& jsonMove);
+    void sendMoveToNetwork(const QString &jsonMove, const QString &session_id, const QString &user_id);
 
 public:
     QUrl qmlPath;
+    
+public:
+    QUuid session_id;   // FIXME: Temporary here
+    QUuid user_id;
 };
 
-#endif // CAVOKEQMLGAMEMODEL_H
+#endif  // CAVOKEQMLGAMEMODEL_H

--- a/client/models/cavokeqmlgamemodel.h
+++ b/client/models/cavokeqmlgamemodel.h
@@ -5,6 +5,7 @@
 #include <QObject>
 #include <QUrl>
 #include <QtCore/QUuid>
+#include <QtQuick/QtQuick>
 #include "tictactoelogic.h"
 
 class CavokeQmlGameModel : public QObject {
@@ -17,17 +18,15 @@ public:
 public slots:
     void getMoveFromQml(const QString &jsonMove);
     void getUpdateFromNetwork(const QString &jsonUpdate);
+    void getClosingFromQml(QQuickCloseEvent *close);
 
 signals:
     void receiveUpdate(QString jsonUpdate);
-    void sendMoveToNetwork(const QString &jsonMove, const QString &session_id, const QString &user_id);
+    void sendMoveToNetwork(const QString &jsonMove);
+    void closingQml();
 
 public:
     QUrl qmlPath;
-    
-public:
-    QUuid session_id;   // FIXME: Temporary here
-    QUuid user_id;
 };
 
 #endif  // CAVOKEQMLGAMEMODEL_H

--- a/client/network_manager.cpp
+++ b/client/network_manager.cpp
@@ -58,9 +58,10 @@ void NetworkManager::gotPostResponse(QNetworkReply *reply) {
 
 void NetworkManager::getUpdate(const QString &sessionId,
                                const QString &user_id) {
-    QUrl route = HOST.resolved(PLAY);
-    route = route.resolved(QUrl(sessionId));
-    route = route.resolved(GET_UPDATE); // ???
+//    QUrl route = HOST.resolved(PLAY);
+//    route = route.resolved(QUrl(sessionId));
+//    route = route.resolved(GET_UPDATE); // ???
+    QUrl route = HOST.resolved(PLAY.toString() + "/" + sessionId + GET_UPDATE.toString());
     route.setQuery(QUrlQuery({QPair<QString, QString>("user_id", user_id)}));
     qDebug() << route.toString();
     auto request = QNetworkRequest(route);

--- a/client/network_manager.cpp
+++ b/client/network_manager.cpp
@@ -1,5 +1,10 @@
 #include "network_manager.h"
 NetworkManager::NetworkManager(QObject *parent) : manager(parent) {
+    pollingTimer = new QTimer(this);
+    pollingTimer->setInterval(500);
+    pollingTimer->callOnTimeout([this]() {
+      getUpdate();
+    });
 }
 void NetworkManager::doTestHealthCheck() {
     auto reply = manager.get(QNetworkRequest(HOST.resolved(HEALTH)));
@@ -81,11 +86,6 @@ void NetworkManager::gotUpdate(QNetworkReply *reply) {
 void NetworkManager::startPolling() {
     sessionId = QUuid::createUuid();
     userId = QUuid::createUuid();
-    pollingTimer = new QTimer(this);
-    pollingTimer->setInterval(500);
-    pollingTimer->callOnTimeout([this]() {
-      getUpdate();
-    });
     pollingTimer->start();
 }
 

--- a/client/network_manager.h
+++ b/client/network_manager.h
@@ -34,6 +34,8 @@ private slots:
 private:
     QNetworkAccessManager manager;
     QTimer *pollingTimer = nullptr;
+    QUuid sessionId;
+    QUuid userId;
     const static inline QUrl HOST{
 #ifdef MOCK
         "https://764bbfca-c45a-46fc-9c79-11d9094b9ba8.mock.pstmn.io/"
@@ -46,8 +48,6 @@ private:
     const static inline QUrl PLAY{"/play"};
     const static inline QUrl SEND_MOVE{"/send_move"};
     const static inline QUrl GET_UPDATE{"/get_update"};
-    QUuid sessionId;
-    QUuid userId;
 };
 
 #endif  // CAVOKE_CLIENT_NETWORK_MANAGER_H

--- a/client/network_manager.h
+++ b/client/network_manager.h
@@ -5,6 +5,7 @@
 #include <QtCore/QJsonDocument>
 #include <QtNetwork/QNetworkAccessManager>
 #include <QtNetwork/QNetworkReply>
+#include <QUrlQuery>
 struct NetworkManager : public QObject {
     Q_OBJECT
 public:
@@ -13,13 +14,22 @@ public:
 public slots:
     void doTestHealthCheck();
     void getGamesList();
-
+    void sendMove(const QString &sessionId,
+                  const QString &jsonMove,
+                  const QString &user_id);
+    void getUpdate(const QString &sessionId,
+                    const QString &user_id);
+    
 signals:
     void finalizedGamesList(QJsonArray list);
+    void gotGameUpdate(const QString &jsonField);
+    
 
 private slots:
     void doneTestHealthCheck(QNetworkReply *reply);
     void gotGamesList(QNetworkReply *reply);
+    void gotPostResponse(QNetworkReply *reply);
+    void gotUpdate(QNetworkReply *reply);
 
 private:
     QNetworkAccessManager manager;
@@ -32,6 +42,9 @@ private:
     };
     const static inline QUrl HEALTH{"/health"};  // FIXME: move to routes module
     const static inline QUrl GAMES_LIST{"/games/list"};
+    const static inline QUrl PLAY{"/play"};
+    const static inline QUrl SEND_MOVE{"/send_move"};
+    const static inline QUrl GET_UPDATE{"/get_update"};
 };
 
 #endif  // CAVOKE_CLIENT_NETWORK_MANAGER_H

--- a/client/network_manager.h
+++ b/client/network_manager.h
@@ -1,11 +1,12 @@
 #ifndef CAVOKE_CLIENT_NETWORK_MANAGER_H
 #define CAVOKE_CLIENT_NETWORK_MANAGER_H
 
+#include <QUrlQuery>
 #include <QtCore/QJsonArray>
 #include <QtCore/QJsonDocument>
+#include <QtCore/QTimer>
 #include <QtNetwork/QNetworkAccessManager>
 #include <QtNetwork/QNetworkReply>
-#include <QUrlQuery>
 struct NetworkManager : public QObject {
     Q_OBJECT
 public:
@@ -14,11 +15,10 @@ public:
 public slots:
     void doTestHealthCheck();
     void getGamesList();
-    void sendMove(const QString &sessionId,
-                  const QString &jsonMove,
-                  const QString &user_id);
-    void getUpdate(const QString &sessionId,
-                    const QString &user_id);
+    void sendMove(const QString &jsonMove);
+    void getUpdate();
+    void startPolling();
+    void stopPolling();
     
 signals:
     void finalizedGamesList(QJsonArray list);
@@ -33,6 +33,7 @@ private slots:
 
 private:
     QNetworkAccessManager manager;
+    QTimer *pollingTimer = nullptr;
     const static inline QUrl HOST{
 #ifdef MOCK
         "https://764bbfca-c45a-46fc-9c79-11d9094b9ba8.mock.pstmn.io/"
@@ -45,6 +46,8 @@ private:
     const static inline QUrl PLAY{"/play"};
     const static inline QUrl SEND_MOVE{"/send_move"};
     const static inline QUrl GET_UPDATE{"/get_update"};
+    QUuid sessionId;
+    QUuid userId;
 };
 
 #endif  // CAVOKE_CLIENT_NETWORK_MANAGER_H

--- a/client/tictactoe-files/content/interactions.js
+++ b/client/tictactoe-files/content/interactions.js
@@ -1,10 +1,5 @@
 function processResponse(response) {
-    var parts = response.split("\n"); // Result, Board
-    updateBoard(parts[1]);
-    if (parts[0].endsWith("wins")) {
-        gameFinished(parts[0]);
-    }
-    
+    updateBoard(response);
 }
 
 function updateBoard(boardString) {

--- a/client/tictactoe-files/tic-tac-toe.qml
+++ b/client/tictactoe-files/tic-tac-toe.qml
@@ -79,7 +79,7 @@ Rectangle {
                     height: board.height/3
 
                     onClicked: {
-                            cavoke.sendMove("M " + String(index));
+                            cavoke.getMoveFromQml("X " + String(index));
                     }
                 }
             }
@@ -91,15 +91,15 @@ Rectangle {
 
             Button {
                 text: "Hard"
-                onClicked: { cavoke.sendMove("D 1.0"); }
+                onClicked: { cavoke.getMoveFromQml("D 1.0"); }
             }
             Button {
                 text: "Moderate"
-                onClicked: { cavoke.sendMove("D 0.8"); }
+                onClicked: { cavoke.getMoveFromQml("D 0.8"); }
             }
             Button {
                 text: "Easy"
-                onClicked: { cavoke.sendMove("D 0.2"); }
+                onClicked: { cavoke.getMoveFromQml("D 0.2"); }
             }
         }
     }

--- a/client/views/joingameview.cpp
+++ b/client/views/joingameview.cpp
@@ -14,3 +14,8 @@ void JoinGameView::on_backButton_clicked() {
     this->close();
     emit shownStartView();
 }
+
+void JoinGameView::on_joinTicTacToeButton_clicked() {
+    this->close();
+    emit joinedTicTacToe();
+}

--- a/client/views/joingameview.h
+++ b/client/views/joingameview.h
@@ -15,9 +15,11 @@ public:
 
 signals:
     void shownStartView();
+    void joinedTicTacToe();
 
 private slots:
     void on_backButton_clicked();
+    void on_joinTicTacToeButton_clicked();
 
 private:
     Ui::JoinGameView *ui;

--- a/client/views/joingameview.ui
+++ b/client/views/joingameview.ui
@@ -40,6 +40,19 @@
      <string>Join game view. Empty.</string>
     </property>
    </widget>
+   <widget class="QPushButton" name="joinTicTacToeButton">
+    <property name="geometry">
+     <rect>
+      <x>240</x>
+      <y>230</y>
+      <width>171</width>
+      <height>41</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>JoinTicTacToe</string>
+    </property>
+   </widget>
   </widget>
   <widget class="QMenuBar" name="menubar">
    <property name="geometry">


### PR DESCRIPTION
Окончательный вариант временной фичи: с экрана  `JoinGame` можно подключиться к крестикам-ноликам, если параллельно запущен сервер. Qml можно закрыть, и всё будет корректно. Состояние обновляется через запросы к серверу каждые 0.5 секунд. 