### PR TITLE
feature/list-of-available-games

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(cavoke_client
         views/joingameview.cpp
         views/creategameview.cpp
         views/settingsview.cpp
+        views/gameslistview.cpp
         tictactoelogic.cpp
         cache_manager.cpp
         network_manager.cpp

--- a/client/cache_manager.cpp
+++ b/client/cache_manager.cpp
@@ -16,8 +16,8 @@ QString cache_manager::get_cached_app_path(QString app_name) {
     return qml_file.fileName();
 }
 
-QString cache_manager::save_zip_to_cache(QFile archive_file) {
-    QFileInfo archiveFileInfo(archive_file.fileName());
+QString cache_manager::save_zip_to_cache(const QFile *archive_file) {
+    QFileInfo archiveFileInfo(archive_file->fileName());
     QString app_name = archiveFileInfo.baseName();
     QDir app_dir(APPS_DIR.filePath(app_name));
 
@@ -25,12 +25,12 @@ QString cache_manager::save_zip_to_cache(QFile archive_file) {
         app_dir.removeRecursively();
     }
 
-    unzip_to_folder(archive_file, APPS_DIR);
+    unzip_to_folder(*archive_file, APPS_DIR);
 
     return app_dir.filePath("app.qml");
 }
 
-void cache_manager::unzip_to_folder(QFile &archive_file, const QDir &dest_dir) {
+void cache_manager::unzip_to_folder(const QFile &archive_file, const QDir &dest_dir) {
     if (!archive_file.exists()) {
         qDebug() << "Can not unpack the archive: " << archive_file.fileName() << " does not exists\n";
         return;

--- a/client/cache_manager.h
+++ b/client/cache_manager.h
@@ -13,9 +13,9 @@ namespace cache_manager {
 
     QString get_cached_app_path(QString app_name);
 
-    QString save_zip_to_cache(QFile archive);
+    QString save_zip_to_cache(const QFile *archive);
 
-    void unzip_to_folder(QFile &archive, const QDir &dest);
+    void unzip_to_folder(const QFile &archive, const QDir &dest);
 
 
 }

--- a/client/controllers/cavokeclientcontroller.cpp
+++ b/client/controllers/cavokeclientcontroller.cpp
@@ -22,6 +22,8 @@ CavokeClientController::CavokeClientController(QObject *parent)
             SLOT(showStartView()));
     connect(&createGameView, SIGNAL(shownStartView()), this,
             SLOT(showStartView()));
+    connect(&gamesListView, SIGNAL(shownStartView()), this,
+            SLOT(showStartView()));
     connect(&settingsView, SIGNAL(shownStartView()), this,
             SLOT(showStartView()));
 
@@ -31,6 +33,8 @@ CavokeClientController::CavokeClientController(QObject *parent)
             SLOT(showJoinGameView()));
     connect(&startView, SIGNAL(shownCreateGameView()), this,
             SLOT(showCreateGameView()));
+    connect(&startView, SIGNAL(shownGamesListView()), this,
+            SLOT(showGamesListView()));
     connect(&startView, SIGNAL(shownSettingsView()), this,
             SLOT(showSettingsView()));
 
@@ -69,6 +73,10 @@ void CavokeClientController::showJoinGameView() {
     joinGameView.show();
 }
 
+void CavokeClientController::showGamesListView() {
+    gamesListView.show();
+}
+
 void CavokeClientController::showCreateGameView() {
     createGameView.show();
 }
@@ -103,6 +111,7 @@ void CavokeClientController::startQmlApplication(
 void CavokeClientController::exitApplication() {
     testWindowView.close();
     joinGameView.close();
+    gamesListView.close();
     createGameView.close();
     startView.close();
 }

--- a/client/controllers/cavokeclientcontroller.cpp
+++ b/client/controllers/cavokeclientcontroller.cpp
@@ -48,23 +48,30 @@ CavokeClientController::CavokeClientController(QObject *parent)
             SLOT(updateGamesList(QJsonArray)));
     connect(&model, SIGNAL(gamesListUpdated(std::vector<GameInfo>)),
             &createGameView, SLOT(gotGamesListUpdate(std::vector<GameInfo>)));
-    
+
     connect(&model, SIGNAL(gamesListUpdated(std::vector<GameInfo>)),
             &gamesListView, SLOT(gotGamesListUpdate(std::vector<GameInfo>)));
-    
+
     connect(&createGameView, SIGNAL(currentIndexChanged(int)), &model,
             SLOT(receivedGameIndexChange(int)));
     connect(&model, SIGNAL(updateSelectedGame(GameInfo)), &createGameView,
             SLOT(gotNewSelectedGame(GameInfo)));
-    
-    connect(&gamesListView, SIGNAL(currentIndexChanged(int)), &model, SLOT(receivedGameIndexChangeInList(int)));
-    connect(&model, SIGNAL(updateSelectedGameInList(GameInfo)), &gamesListView, SLOT(gotNewSelectedGame(GameInfo)));
+
+    connect(&gamesListView, SIGNAL(currentIndexChanged(int)), &model,
+            SLOT(receivedGameIndexChangeInList(int)));
+    connect(&model, SIGNAL(updateSelectedGameInList(GameInfo)), &gamesListView,
+            SLOT(gotNewSelectedGame(GameInfo)));
 
     connect(&joinGameView, SIGNAL(joinedTicTacToe(QString)), this,
             SLOT(startQmlByPath(QString)));
-    
-    connect(&gamesListView, SIGNAL(requestedDownloadGame(int)), &model, SLOT(gotIndexToDownload(int)));
-    connect(&model, SIGNAL(downloadGame(QString)), &networkManager, SLOT(downloadGame(QString)));
+
+    connect(&gamesListView, SIGNAL(requestedDownloadGame(int)), &model,
+            SLOT(gotIndexToDownload(int)));
+    connect(&model, SIGNAL(downloadGame(QString)), &networkManager,
+            SLOT(downloadGame(QString)));
+
+    connect(&networkManager, SIGNAL(downloadedGameFile(QFile *)), this,
+            SLOT(updackDownloadedQml(QFile *)));
 
     startView.show();
 
@@ -141,4 +148,9 @@ void CavokeClientController::stopQml() {
     startView.show();
     currentQmlGameModel->deleteLater();
     networkManager.stopPolling();
+}
+
+void CavokeClientController::unpackDownloadedQml(const QFile *file) {
+    cache_manager::save_zip_to_cache(file);
+    
 }

--- a/client/controllers/cavokeclientcontroller.cpp
+++ b/client/controllers/cavokeclientcontroller.cpp
@@ -71,7 +71,7 @@ CavokeClientController::CavokeClientController(QObject *parent)
             SLOT(downloadGame(QString)));
 
     connect(&networkManager, SIGNAL(downloadedGameFile(QFile *)), this,
-            SLOT(updackDownloadedQml(QFile *)));
+            SLOT(unpackDownloadedQml(QFile *)));
 
     startView.show();
 
@@ -150,7 +150,8 @@ void CavokeClientController::stopQml() {
     networkManager.stopPolling();
 }
 
-void CavokeClientController::unpackDownloadedQml(const QFile *file) {
+void CavokeClientController::unpackDownloadedQml(QFile *file) {
     cache_manager::save_zip_to_cache(file);
-    
+    qDebug() << "At least I finished";
+    file->deleteLater();
 }

--- a/client/controllers/cavokeclientcontroller.cpp
+++ b/client/controllers/cavokeclientcontroller.cpp
@@ -56,6 +56,9 @@ CavokeClientController::CavokeClientController(QObject *parent)
             SLOT(receivedGameIndexChange(int)));
     connect(&model, SIGNAL(updateSelectedGame(GameInfo)), &createGameView,
             SLOT(gotNewSelectedGame(GameInfo)));
+    
+    connect(&gamesListView, SIGNAL(currentIndexChanged(int)), &model, SLOT(receivedGameIndexChangeInList(int)));
+    connect(&model, SIGNAL(updateSelectedGameInList(GameInfo)), &gamesListView, SLOT(gotNewSelectedGame(GameInfo)));
 
     connect(&joinGameView, SIGNAL(joinedTicTacToe(QString)), this,
             SLOT(startQmlByPath(QString)));

--- a/client/controllers/cavokeclientcontroller.cpp
+++ b/client/controllers/cavokeclientcontroller.cpp
@@ -48,6 +48,10 @@ CavokeClientController::CavokeClientController(QObject *parent)
             SLOT(updateGamesList(QJsonArray)));
     connect(&model, SIGNAL(gamesListUpdated(std::vector<GameInfo>)),
             &createGameView, SLOT(gotGamesListUpdate(std::vector<GameInfo>)));
+    
+    connect(&model, SIGNAL(gamesListUpdated(std::vector<GameInfo>)),
+            &gamesListView, SLOT(gotGamesListUpdate(std::vector<GameInfo>)));
+    
     connect(&createGameView, SIGNAL(currentIndexChanged(int)), &model,
             SLOT(receivedGameIndexChange(int)));
     connect(&model, SIGNAL(updateSelectedGame(GameInfo)), &createGameView,

--- a/client/controllers/cavokeclientcontroller.cpp
+++ b/client/controllers/cavokeclientcontroller.cpp
@@ -62,6 +62,9 @@ CavokeClientController::CavokeClientController(QObject *parent)
 
     connect(&joinGameView, SIGNAL(joinedTicTacToe(QString)), this,
             SLOT(startQmlByPath(QString)));
+    
+    connect(&gamesListView, SIGNAL(requestedDownloadGame(int)), &model, SLOT(gotIndexToDownload(int)));
+    connect(&model, SIGNAL(downloadGame(QString)), &networkManager, SLOT(downloadGame(QString)));
 
     startView.show();
 

--- a/client/controllers/cavokeclientcontroller.h
+++ b/client/controllers/cavokeclientcontroller.h
@@ -1,6 +1,7 @@
 #ifndef CAVOKECLIENTCONTROLLER_H
 #define CAVOKECLIENTCONTROLLER_H
 
+#include <views/gameslistview.h>
 #include <QObject>
 #include <QtQuick>
 #include "cavokeclientmodel.h"
@@ -20,6 +21,7 @@ public slots:
     void showTestWindowView();
     void showStartView();
     void showJoinGameView();
+    void showGamesListView();
     void showCreateGameView();
     void showSettingsView();
 
@@ -39,6 +41,7 @@ private:
     StartView startView;
     JoinGameView joinGameView;
     CreateGameView createGameView;
+    GamesListView gamesListView;
     SettingsView settingsView;
     CavokeQmlGameModel *currentQmlGameModel = nullptr;
 };

--- a/client/controllers/cavokeclientcontroller.h
+++ b/client/controllers/cavokeclientcontroller.h
@@ -34,7 +34,7 @@ private slots:
     void exitApplication();
     void startQmlByPath(const QString &path);
     void stopQml();
-    void unpackDownloadedQml(const QFile *file);
+    void unpackDownloadedQml(QFile *file);
 
 private:
     NetworkManager networkManager;

--- a/client/controllers/cavokeclientcontroller.h
+++ b/client/controllers/cavokeclientcontroller.h
@@ -11,6 +11,7 @@
 #include "settingsview.h"
 #include "startview.h"
 #include "testwindowview.h"
+#include <cache_manager.h>
 
 class CavokeClientController : public QObject {
     Q_OBJECT
@@ -33,6 +34,7 @@ private slots:
     void exitApplication();
     void startQmlByPath(const QString &path);
     void stopQml();
+    void unpackDownloadedQml(const QFile *file);
 
 private:
     NetworkManager networkManager;

--- a/client/models/cavokeclientmodel.cpp
+++ b/client/models/cavokeclientmodel.cpp
@@ -30,3 +30,8 @@ void CavokeClientModel::updateGamesList(const QJsonArray &newGamesList) {
 void CavokeClientModel::receivedGameIndexChange(int newIndex) {
     emit updateSelectedGame(gamesList[newIndex]);
 }
+
+void CavokeClientModel::receivedGameIndexChangeInList(int newIndex) {
+    qDebug() << "HERE!!";
+    emit updateSelectedGameInList(gamesList[newIndex]);
+}

--- a/client/models/cavokeclientmodel.cpp
+++ b/client/models/cavokeclientmodel.cpp
@@ -32,6 +32,10 @@ void CavokeClientModel::receivedGameIndexChange(int newIndex) {
 }
 
 void CavokeClientModel::receivedGameIndexChangeInList(int newIndex) {
-    qDebug() << "HERE!!";
     emit updateSelectedGameInList(gamesList[newIndex]);
+}
+
+void CavokeClientModel::gotIndexToDownload(int index) {
+    qDebug() << gamesList[index].id;
+    emit downloadGame(gamesList[index].id);
 }

--- a/client/models/cavokeclientmodel.h
+++ b/client/models/cavokeclientmodel.h
@@ -15,11 +15,13 @@ public slots:
     void updateGamesList(const QJsonArray &newGamesList);
     void receivedGameIndexChange(int newIndex);
     void receivedGameIndexChangeInList(int newIndex);
+    void gotIndexToDownload(int index);
 signals:
     void startQmlApplication(CavokeQmlGameModel *);
     void gamesListUpdated(const std::vector<GameInfo> &newGamesList);
     void updateSelectedGame(const GameInfo &gameInfo);
     void updateSelectedGameInList(const GameInfo &gameInfo);
+    void downloadGame(const QString &gameId);
 
 private:
     std::vector<GameInfo> gamesList;

--- a/client/models/cavokeclientmodel.h
+++ b/client/models/cavokeclientmodel.h
@@ -14,10 +14,12 @@ public slots:
     void loadQmlGame(const QString &gameName);
     void updateGamesList(const QJsonArray &newGamesList);
     void receivedGameIndexChange(int newIndex);
+    void receivedGameIndexChangeInList(int newIndex);
 signals:
     void startQmlApplication(CavokeQmlGameModel *);
     void gamesListUpdated(const std::vector<GameInfo> &newGamesList);
     void updateSelectedGame(const GameInfo &gameInfo);
+    void updateSelectedGameInList(const GameInfo &gameInfo);
 
 private:
     std::vector<GameInfo> gamesList;

--- a/client/network_manager.cpp
+++ b/client/network_manager.cpp
@@ -84,3 +84,25 @@ void NetworkManager::startPolling() {
 void NetworkManager::stopPolling() {
     pollingTimer->stop();
 }
+
+void NetworkManager::downloadGame(const QString &gameId) {
+    QUrl route = HOST.resolved(GAMES)
+        .resolved(gameId + "/")
+        .resolved(GET_CLIENT);
+    qDebug() << route.toString();
+    auto request = QNetworkRequest(route);
+    auto reply = manager.get(request);
+    connect(reply, &QNetworkReply::finished, this,
+            [reply, this]() { gotGameDownloaded(reply); });
+}
+
+void NetworkManager::gotGameDownloaded(QNetworkReply *reply) {
+    if (reply->error()) {
+        qDebug() << reply->errorString();
+        return;
+    }
+    QString answer = reply->readAll();
+    reply->close();
+    reply->deleteLater();
+    qDebug() << answer;
+}

--- a/client/network_manager.cpp
+++ b/client/network_manager.cpp
@@ -1,4 +1,5 @@
 #include "network_manager.h"
+
 NetworkManager::NetworkManager(QObject *parent) : manager(parent) {
     pollingTimer = new QTimer(this);
     pollingTimer->setInterval(500);
@@ -101,8 +102,16 @@ void NetworkManager::gotGameDownloaded(QNetworkReply *reply) {
         qDebug() << reply->errorString();
         return;
     }
-    QString answer = reply->readAll();
+    // Probably next part should be in some other place
+    QFile *file = new QTemporaryFile();
+    if (file->open(QFile::WriteOnly)) {
+        file->write(reply->readAll());
+        file->flush();
+        file->close();
+    }
+    emit downloadedGameFile(file);
+    // End of the part
     reply->close();
     reply->deleteLater();
-    qDebug() << answer;
+    
 }

--- a/client/network_manager.h
+++ b/client/network_manager.h
@@ -7,6 +7,8 @@
 #include <QtCore/QTimer>
 #include <QtNetwork/QNetworkAccessManager>
 #include <QtNetwork/QNetworkReply>
+#include <QtCore/QFile>
+#include <QtCore/QTemporaryFile>
 struct NetworkManager : public QObject {
     Q_OBJECT
 public:
@@ -24,6 +26,7 @@ public slots:
 signals:
     void finalizedGamesList(QJsonArray list);
     void gotGameUpdate(const QString &jsonField);
+    void downloadedGameFile(const QFile *file);
 
 private slots:
     void doneTestHealthCheck(QNetworkReply *reply);

--- a/client/network_manager.h
+++ b/client/network_manager.h
@@ -19,6 +19,7 @@ public slots:
     void getUpdate();
     void startPolling();
     void stopPolling();
+    void downloadGame(const QString &gameId);
 
 signals:
     void finalizedGamesList(QJsonArray list);
@@ -29,6 +30,7 @@ private slots:
     void gotGamesList(QNetworkReply *reply);
     void gotPostResponse(QNetworkReply *reply);
     void gotUpdate(QNetworkReply *reply);
+    void gotGameDownloaded(QNetworkReply *reply);
 
 private:
     QNetworkAccessManager manager;
@@ -47,6 +49,8 @@ private:
     const static inline QUrl PLAY{"play/"};
     const static inline QUrl SEND_MOVE{"send_move"};
     const static inline QUrl GET_UPDATE{"get_update"};
+    const static inline QUrl GAMES{"games/"};
+    const static inline QUrl GET_CLIENT{"get_client"};
 };
 
 #endif  // CAVOKE_CLIENT_NETWORK_MANAGER_H

--- a/client/network_manager.h
+++ b/client/network_manager.h
@@ -26,7 +26,7 @@ public slots:
 signals:
     void finalizedGamesList(QJsonArray list);
     void gotGameUpdate(const QString &jsonField);
-    void downloadedGameFile(const QFile *file);
+    void downloadedGameFile(QFile *file);
 
 private slots:
     void doneTestHealthCheck(QNetworkReply *reply);

--- a/client/views/gameslistview.cpp
+++ b/client/views/gameslistview.cpp
@@ -15,3 +15,10 @@ void GamesListView::on_backButton_clicked() {
     this->close();
     emit shownStartView();
 }
+
+void GamesListView::gotGamesListUpdate(
+    const std::vector<GameInfo> &newGamesList) {
+    for (const auto &gameInfo : newGamesList) {
+        ui->gamesListWidget->addItem(gameInfo.display_name);
+    }
+}

--- a/client/views/gameslistview.cpp
+++ b/client/views/gameslistview.cpp
@@ -22,6 +22,10 @@ void GamesListView::on_backButton_clicked() {
     emit shownStartView();
 }
 
+void GamesListView::on_downloadQmlButton_clicked() {
+    emit requestedDownloadGame(ui->gamesListWidget->currentRow());
+}
+
 void GamesListView::gotGamesListUpdate(
     const std::vector<GameInfo> &newGamesList) {
     for (const auto &gameInfo : newGamesList) {

--- a/client/views/gameslistview.cpp
+++ b/client/views/gameslistview.cpp
@@ -5,6 +5,12 @@
 GamesListView::GamesListView(QWidget *parent)
     : QMainWindow(parent), ui(new Ui::GamesListView) {
     ui->setupUi(this);
+    connect(ui->gamesListWidget, SIGNAL(currentRowChanged(int)), this,
+            SLOT(repeaterCurrentIndexChanged(int)));
+}
+
+void GamesListView::repeaterCurrentIndexChanged(int index) {
+    emit currentIndexChanged(index);
 }
 
 GamesListView::~GamesListView() {
@@ -21,4 +27,11 @@ void GamesListView::gotGamesListUpdate(
     for (const auto &gameInfo : newGamesList) {
         ui->gamesListWidget->addItem(gameInfo.display_name);
     }
+}
+
+void GamesListView::gotNewSelectedGame(const GameInfo &gameInfo) {
+    ui->gameNameLabel->setText(gameInfo.display_name);
+    ui->gameDescriptionTextBrowser->setText(gameInfo.description);
+    ui->playersAmountLabel->setText(QString::number(gameInfo.players_num));
+//    ui->createGameButton->setEnabled(true);
 }

--- a/client/views/gameslistview.cpp
+++ b/client/views/gameslistview.cpp
@@ -1,0 +1,17 @@
+#include "gameslistview.h"
+
+#include "ui_gameslistview.h"
+
+GamesListView::GamesListView(QWidget *parent)
+    : QMainWindow(parent), ui(new Ui::GamesListView) {
+    ui->setupUi(this);
+}
+
+GamesListView::~GamesListView() {
+    delete ui;
+}
+
+void GamesListView::on_backButton_clicked() {
+    this->close();
+    emit shownStartView();
+}

--- a/client/views/gameslistview.h
+++ b/client/views/gameslistview.h
@@ -1,6 +1,7 @@
 #ifndef CAVOKE_GAMESLISTVIEW_H
 #define CAVOKE_GAMESLISTVIEW_H
 
+#include <gameinfo.h>
 #include <QMainWindow>
 
 namespace Ui {
@@ -12,7 +13,10 @@ Q_OBJECT
 public:
     explicit GamesListView(QWidget *parent = nullptr);
     ~GamesListView();
-
+    
+public slots:
+    void gotGamesListUpdate(const std::vector<GameInfo> &newGamesList);
+    
 signals:
     void shownStartView();
 

--- a/client/views/gameslistview.h
+++ b/client/views/gameslistview.h
@@ -16,12 +16,15 @@ public:
     
 public slots:
     void gotGamesListUpdate(const std::vector<GameInfo> &newGamesList);
+    void gotNewSelectedGame(const GameInfo &gameInfo);
     
 signals:
     void shownStartView();
+    void currentIndexChanged(int index);
 
 private slots:
     void on_backButton_clicked();
+    void repeaterCurrentIndexChanged(int index);
 
 private:
     Ui::GamesListView *ui;

--- a/client/views/gameslistview.h
+++ b/client/views/gameslistview.h
@@ -21,9 +21,11 @@ public slots:
 signals:
     void shownStartView();
     void currentIndexChanged(int index);
+    void requestedDownloadGame(int index);
 
 private slots:
     void on_backButton_clicked();
+    void on_downloadQmlButton_clicked();
     void repeaterCurrentIndexChanged(int index);
 
 private:

--- a/client/views/gameslistview.h
+++ b/client/views/gameslistview.h
@@ -1,0 +1,26 @@
+#ifndef CAVOKE_GAMESLISTVIEW_H
+#define CAVOKE_GAMESLISTVIEW_H
+
+#include <QMainWindow>
+
+namespace Ui {
+class GamesListView;
+}
+
+class GamesListView : public QMainWindow {
+Q_OBJECT
+public:
+    explicit GamesListView(QWidget *parent = nullptr);
+    ~GamesListView();
+
+signals:
+    void shownStartView();
+
+private slots:
+    void on_backButton_clicked();
+
+private:
+    Ui::GamesListView *ui;
+};
+
+#endif  // CAVOKE_GAMESLISTVIEW_H

--- a/client/views/gameslistview.ui
+++ b/client/views/gameslistview.ui
@@ -46,6 +46,85 @@
      <set>Qt::AlignCenter</set>
     </property>
    </widget>
+   <widget class="QListWidget" name="gamesListWidget">
+    <property name="geometry">
+     <rect>
+      <x>145</x>
+      <y>121</y>
+      <width>371</width>
+      <height>321</height>
+     </rect>
+    </property>
+   </widget>
+   <widget class="QTextBrowser" name="gameDescriptionTextBrowser">
+    <property name="geometry">
+     <rect>
+      <x>540</x>
+      <y>210</y>
+      <width>251</width>
+      <height>121</height>
+     </rect>
+    </property>
+    <property name="html">
+     <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Cantarell'; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Game description&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="gameNameLabel">
+    <property name="geometry">
+     <rect>
+      <x>550</x>
+      <y>130</y>
+      <width>111</width>
+      <height>21</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Game name</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_3">
+    <property name="geometry">
+     <rect>
+      <x>550</x>
+      <y>170</y>
+      <width>111</width>
+      <height>21</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Players allowed:</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="playersAmountLabel">
+    <property name="geometry">
+     <rect>
+      <x>670</x>
+      <y>170</y>
+      <width>57</width>
+      <height>16</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>0</string>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="downloadQmlButton">
+    <property name="geometry">
+     <rect>
+      <x>550</x>
+      <y>370</y>
+      <width>121</width>
+      <height>31</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Download QML</string>
+    </property>
+   </widget>
   </widget>
   <widget class="QMenuBar" name="menubar">
    <property name="geometry">

--- a/client/views/gameslistview.ui
+++ b/client/views/gameslistview.ui
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>GamesListView</class>
+ <widget class="QMainWindow" name="GamesListView">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>800</width>
+    <height>600</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>MainWindow</string>
+  </property>
+  <widget class="QWidget" name="centralwidget">
+   <widget class="QPushButton" name="backButton">
+    <property name="geometry">
+     <rect>
+      <x>40</x>
+      <y>480</y>
+      <width>90</width>
+      <height>32</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Back</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label">
+    <property name="geometry">
+     <rect>
+      <x>250</x>
+      <y>60</y>
+      <width>241</width>
+      <height>41</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>ALL AVAILABLE GAMES ON SERVER</string>
+    </property>
+    <property name="scaledContents">
+     <bool>false</bool>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+   </widget>
+  </widget>
+  <widget class="QMenuBar" name="menubar">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>800</width>
+     <height>28</height>
+    </rect>
+   </property>
+  </widget>
+  <widget class="QStatusBar" name="statusbar"/>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/client/views/gameslistview.ui
+++ b/client/views/gameslistview.ui
@@ -78,7 +78,7 @@ p, li { white-space: pre-wrap; }
      <rect>
       <x>550</x>
       <y>130</y>
-      <width>111</width>
+      <width>221</width>
       <height>21</height>
      </rect>
     </property>

--- a/client/views/startview.cpp
+++ b/client/views/startview.cpp
@@ -21,6 +21,11 @@ void StartView::on_createGameButton_clicked() {
     emit shownCreateGameView();
 }
 
+void StartView::on_gamesListButton_clicked() {
+    this->close();
+    emit shownGamesListView();
+}
+
 void StartView::on_cavokeTestWindowButton_clicked() {
     this->close();
     emit shownTestWindowView();

--- a/client/views/startview.h
+++ b/client/views/startview.h
@@ -19,11 +19,13 @@ signals:
     void shownJoinGameView();
     void shownCreateGameView();
     void shownSettingsView();
+    void shownGamesListView();
     void clickedExitButton();
 
 private slots:
     void on_joinGameButton_clicked();
     void on_createGameButton_clicked();
+    void on_gamesListButton_clicked();
     void on_cavokeTestWindowButton_clicked();
     void on_settingsButton_clicked();
     void on_exitButton_clicked();

--- a/client/views/startview.ui
+++ b/client/views/startview.ui
@@ -29,7 +29,7 @@
          <x>230</x>
          <y>160</y>
          <width>321</width>
-         <height>156</height>
+         <height>194</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -44,6 +44,13 @@
          <widget class="QPushButton" name="createGameButton">
           <property name="text">
            <string>Create game</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="gamesListButton">
+          <property name="text">
+           <string>List all available games</string>
           </property>
          </widget>
         </item>

--- a/client/views/testwindowview.cpp
+++ b/client/views/testwindowview.cpp
@@ -32,7 +32,8 @@ void TestWindowView::on_loadZipButton_clicked() {
                                                    QDir::currentPath(),
                                                    tr("ZIP Archive (*.zip)"));
     if (!zipPath.isNull()) {
-        ui->appPathInput->setText(cache_manager::save_zip_to_cache(zipPath));
+        QFile archiveFile(zipPath);
+        ui->appPathInput->setText(cache_manager::save_zip_to_cache(&archiveFile));
     }
 }
 


### PR DESCRIPTION
Теперь можно загружать архивы с клиентом с сервера!

Добавлен экран с всеми доступными на сервере играми. На экране можно выбрать игру и скачать её.

Архив скачивается во временный файл, затем используя `cache_manager` распаковывается. После этого игру можно запустить, указав путь до неё туда, куда `cache_manager` её распаковал. На линуксе это `.local/share/cavoke_client` и т.д., как на винде -- не знаю. В дальнешем нужно будет добавить при запуске выбирать игру сразу из кэша