### PR TITLE
Feature/game-settings

### DIFF
--- a/games/CMakeLists.txt
+++ b/games/CMakeLists.txt
@@ -4,5 +4,7 @@ project(tictactoe)
 find_package(nlohmann_json 3.9.0 REQUIRED)
 
 add_executable(tictactoe
-        tictactoe/tictactoe.cpp)
+        tictactoe/tictactoe.cpp
+        cavoke.cpp)
+
 target_link_libraries(tictactoe nlohmann_json::nlohmann_json)

--- a/games/cavoke.cpp
+++ b/games/cavoke.cpp
@@ -1,0 +1,26 @@
+#include "cavoke.h"
+
+using json = nlohmann::json;
+
+int main() {
+    std::string input;
+    char c;
+    while (std::cin.get(c)) {
+        input.push_back(c);
+    }
+    std::cerr << "RECEIVED MOVE: '" << input << "'" << std::endl;
+    json input_json = json::parse(input);
+    cavoke::GameMove move = input_json.get<cavoke::GameMove>();
+
+    cavoke::GameState new_state;
+    if (move.player_id == -1) {
+        new_state = cavoke::init_state();
+    } else {
+        new_state = cavoke::apply_move(move);
+    }
+
+    json result_json = new_state;
+
+    std::cerr << "SEND RESULT: '" << result_json << "'" << std::endl;
+    std::cout << result_json;
+}

--- a/games/cavoke.cpp
+++ b/games/cavoke.cpp
@@ -1,25 +1,48 @@
 #include "cavoke.h"
+#include <utility>
 
 using json = nlohmann::json;
 
 int main() {
-    std::string input;
+    // supported commands
+    // 1. VALIDATE <GameSettings>
+    // 2. INIT <GameSettings>
+    // 3. MOVE <GameMove>
+
+    std::string command;
+    std::cin >> command;
+
+    std::string argument;
     char c;
     while (std::cin.get(c)) {
-        input.push_back(c);
+        argument.push_back(c);
     }
-    std::cerr << "RECEIVED MOVE: '" << input << "'" << std::endl;
-    json input_json = json::parse(input);
-    cavoke::GameMove move = input_json.get<cavoke::GameMove>();
 
-    cavoke::GameState new_state;
-    if (move.player_id == -1) {
-        new_state = cavoke::init_state();
+    std::cerr << "RECEIVED COMMAND: '" << command << ' ' << argument << "'"
+              << std::endl;
+
+    json argument_json = json::parse(argument);
+    json result_json;
+
+    if (command == "VALIDATE") {
+        cavoke::GameSettings settings =
+            argument_json.get<cavoke::GameSettings>();
+        std::string message;
+        bool success = cavoke::validate_settings(
+            settings.settings, settings.occupied_positions,
+            [&message](std::string message_) {
+                message = std::move(message_);
+            });
+        result_json = cavoke::ValidationResult{success, message};
+    } else if (command == "INIT") {
+        cavoke::GameSettings settings =
+            argument_json.get<cavoke::GameSettings>();
+        result_json =
+            cavoke::init_state(settings.settings, settings.occupied_positions);
     } else {
-        new_state = cavoke::apply_move(move);
+        cavoke::GameMove move = argument_json.get<cavoke::GameMove>();
+        result_json = cavoke::apply_move(move);
     }
-
-    json result_json = new_state;
 
     std::cerr << "SEND RESULT: '" << result_json << "'" << std::endl;
     std::cout << result_json;

--- a/games/cavoke.cpp
+++ b/games/cavoke.cpp
@@ -25,8 +25,8 @@ int main() {
     json result_json;
 
     if (command == "VALIDATE") {
-        cavoke::GameSettings settings =
-            argument_json.get<cavoke::GameSettings>();
+        cavoke::InitSettings settings =
+            argument_json.get<cavoke::InitSettings>();
         std::string message;
         bool success = cavoke::validate_settings(
             settings.settings, settings.occupied_positions,
@@ -35,8 +35,8 @@ int main() {
             });
         result_json = cavoke::ValidationResult{success, message};
     } else if (command == "INIT") {
-        cavoke::GameSettings settings =
-            argument_json.get<cavoke::GameSettings>();
+        cavoke::InitSettings settings =
+            argument_json.get<cavoke::InitSettings>();
         result_json =
             cavoke::init_state(settings.settings, settings.occupied_positions);
     } else {

--- a/games/cavoke.h
+++ b/games/cavoke.h
@@ -41,6 +41,7 @@ struct ValidationResult {
     bool success;
     std::string message;
 };
+
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(ValidationResult, success, message);
 
 // called every time admin changes settings or new player arrives

--- a/games/cavoke.h
+++ b/games/cavoke.h
@@ -6,7 +6,9 @@
 #include <string>
 #include <vector>
 
+// TODO: logging
 namespace cavoke {
+using json = nlohmann::json;
 
 struct GameState {  // NOLINT(cppcoreguidelines-pro-type-member-init)
     bool is_terminal;
@@ -29,36 +31,30 @@ struct GameMove {  // NOLINT(cppcoreguidelines-pro-type-member-init)
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(GameMove, player_id, move, global_state)
 
-GameState init_state();
+namespace {
+
+struct ValidationResult {
+    bool success;
+    std::string message;
+};
+
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(ValidationResult, success, message);
+
+}  // namespace
+
+// called every time admin changes settings or new player arrives
+// returns true if game can be started with current settings; false otherwise
+// use message_callback(<some_message>) to display message to the players
+bool validate_settings(const json &settings, const std::vector<int> &occupied_positions, const std::function<void(std::string)> &message_callback);
+
+// called once when the game session is started
+// generates initial state
+// settings have passed the validation
+GameState init_state(const json &settings, const std::vector<int> &occupied_positions);
+
+// applies move to the state
 GameState apply_move(GameMove &new_move);
 
-// TODO: logging
-
 }  // namespace cavoke
-
-using json = nlohmann::json;
-
-int main() {
-    std::string input;
-    char c;
-    while (std::cin.get(c)) {
-        input.push_back(c);
-    }
-    std::cerr << "RECEIVED MOVE: '" << input << "'" << std::endl;
-    json input_json = json::parse(input);
-    cavoke::GameMove move = input_json.get<cavoke::GameMove>();
-
-    cavoke::GameState new_state;
-    if (move.player_id == -1) {
-        new_state = cavoke::init_state();
-    } else {
-        new_state = cavoke::apply_move(move);
-    }
-
-    json result_json = new_state;
-
-    std::cerr << "SEND RESULT: '" << result_json << "'" << std::endl;
-    std::cout << result_json;
-}
 
 #endif  // CAVOKE_CAVOKE_H

--- a/games/cavoke.h
+++ b/games/cavoke.h
@@ -16,7 +16,6 @@ struct GameState {  // NOLINT(cppcoreguidelines-pro-type-member-init)
     std::vector<std::string> players_state;
     std::vector<int> winners;
 };
-
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(GameState,
                                    is_terminal,
                                    global_state,
@@ -28,29 +27,35 @@ struct GameMove {  // NOLINT(cppcoreguidelines-pro-type-member-init)
     std::string move;
     std::string global_state;
 };
-
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(GameMove, player_id, move, global_state)
 
-namespace {
+struct GameSettings {
+    json settings;
+    std::vector<int> occupied_positions;
+};
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(GameSettings,
+                                   settings,
+                                   occupied_positions);
 
 struct ValidationResult {
     bool success;
     std::string message;
 };
-
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(ValidationResult, success, message);
-
-}  // namespace
 
 // called every time admin changes settings or new player arrives
 // returns true if game can be started with current settings; false otherwise
 // use message_callback(<some_message>) to display message to the players
-bool validate_settings(const json &settings, const std::vector<int> &occupied_positions, const std::function<void(std::string)> &message_callback);
+bool validate_settings(
+    const json &settings,
+    const std::vector<int> &occupied_positions,
+    const std::function<void(std::string)> &message_callback);
 
 // called once when the game session is started
 // generates initial state
 // settings have passed the validation
-GameState init_state(const json &settings, const std::vector<int> &occupied_positions);
+GameState init_state(const json &settings,
+                     const std::vector<int> &occupied_positions);
 
 // applies move to the state
 GameState apply_move(GameMove &new_move);

--- a/games/cavoke.h
+++ b/games/cavoke.h
@@ -29,11 +29,11 @@ struct GameMove {  // NOLINT(cppcoreguidelines-pro-type-member-init)
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(GameMove, player_id, move, global_state)
 
-struct GameSettings {
+struct InitSettings {
     json settings;
     std::vector<int> occupied_positions;
 };
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(GameSettings,
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(InitSettings,
                                    settings,
                                    occupied_positions);
 

--- a/games/tictactoe/tictactoe.cpp
+++ b/games/tictactoe/tictactoe.cpp
@@ -13,7 +13,7 @@ bool validate_settings(
     }
 
     if (!settings.contains("board_size")) {
-        message_callback("No bord_size property");
+        message_callback("No board_size property");
         return false;
     }
 
@@ -33,7 +33,7 @@ int get_board_size(const std::string &board) {
 char current_player(std::string &board) {
     int xs_cnt = 0;
     int os_cnt = 0;
-    for (int i = 0; i < get_board_size(board); ++i) {
+    for (int i = 0; i < board.size(); ++i) {
         if (board[i] == 'X') {
             xs_cnt++;
         } else if (board[i] == 'O') {
@@ -54,26 +54,82 @@ int extract_position(std::string &move) {
 };
 
 bool is_valid_move(std::string &board, int position) {
-    return position > 0 && position < board.size() && board[position] == ' ';
+    return position >= 0 && position < board.size() && board[position] == ' ';
+}
+
+int coord_to_pos(int x, int y, int board_size) {
+    return x * board_size + y;
 }
 
 // TODO: fix for 5x5 board
 bool winner(const std::string &board) {
-    for (int i = 0; i < get_board_size(board); ++i) {
-        if (board[i] != ' ' && board[i] == board[i + 3] &&
-            board[i] == board[i + 6])
-            return true;
+    int board_size = get_board_size(board);
+    int row_to_win = (board_size == 3 ? 3 : 4);
 
-        if (board[i * 3] != ' ' && board[i * 3] == board[i * 3 + 1] &&
-            board[i * 3] == board[i * 3 + 2])
-            return true;
+    for (int i = 0; i < board_size; ++i) {
+        for (int j = 0; j < board_size; ++j) {
+            char cur = board[coord_to_pos(i, j, board_size)];
+            if (cur == ' ') {
+                continue;
+            }
+
+            // vertical
+            if (i + row_to_win <= board_size) {
+                bool flag = true;
+                for (int k = 1; k < row_to_win; ++k) {
+                    if (board[coord_to_pos(i + k, j, board_size)] != cur) {
+                        flag = false;
+                        break;
+                    }
+                }
+                if (flag) {
+                    return true;
+                }
+            }
+
+            // horizontal
+            if (j + row_to_win <= board_size) {
+                bool flag = true;
+                for (int k = 1; k < row_to_win; ++k) {
+                    if (board[coord_to_pos(i, j + k, board_size)] != cur) {
+                        flag = false;
+                        break;
+                    }
+                }
+                if (flag) {
+                    return true;
+                }
+            }
+
+            // diag 1
+            if (i + row_to_win <= board_size && j + row_to_win <= board_size) {
+                bool flag = true;
+                for (int k = 1; k < row_to_win; ++k) {
+                    if (board[coord_to_pos(i + k, j + k, board_size)] != cur) {
+                        flag = false;
+                        break;
+                    }
+                }
+                if (flag) {
+                    return true;
+                }
+            }
+
+            // diag 2
+            if (i - row_to_win >= -1 && j + row_to_win <= board_size) {
+                bool flag = true;
+                for (int k = 1; k < row_to_win; ++k) {
+                    if (board[coord_to_pos(i - k, j + k, board_size)] != cur) {
+                        flag = false;
+                        break;
+                    }
+                }
+                if (flag) {
+                    return true;
+                }
+            }
+        }
     }
-
-    if (board[0] != ' ' && board[0] == board[4] && board[0] == board[8])
-        return true;
-
-    if (board[2] != ' ' && board[2] == board[4] && board[2] == board[6])
-        return true;
 
     return false;
 }

--- a/server/controllers/sessions_controller.cpp
+++ b/server/controllers/sessions_controller.cpp
@@ -38,9 +38,13 @@ void cavoke::server::controllers::SessionsController::create(
     }
 
     // configurate initial state for session
+
+    // TODO: validate settings
+    // TODO: get actual connected players
     m_game_state_storage->save_state(
         session_info.session_id,
-        m_game_logic_manager->send_move(game_id.value(), {-1, "", ""}));
+        m_game_logic_manager->init_state(
+            game_id.value(), game.value().config.default_settings, {0, 1}));
 
     return callback(newNlohmannJsonResponse(session_info));
 }

--- a/server/controllers/state_controller.cpp
+++ b/server/controllers/state_controller.cpp
@@ -43,16 +43,7 @@ void StateController::send_move(
         m_game_state_storage->get_state(session_id);
 
     if (!current_state.has_value()) {
-        // new session
-        auto game = m_games_storage->get_game_by_id(session_info.game_id);
-        if (!game.has_value()) {
-            return CALLBACK_STATUS_CODE(k400BadRequest);
-        }
-
-        // TODO: validate settings
-        // TODO: get actual connected players
-        current_state = m_game_logic_manager->init_state(
-            session_info.game_id, game.value().config.default_settings, {});
+        return CALLBACK_STATUS_CODE(k400BadRequest);
     }
 
     if (current_state->is_terminal) {

--- a/server/model/game.h
+++ b/server/model/game.h
@@ -13,6 +13,7 @@ struct GameConfig {
     std::string display_name;
     std::string description;
     int players_num;
+    json default_settings;
 
     /// Validates config. Throws an exception if invalid
     void validate() const {
@@ -24,7 +25,8 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(GameConfig,
                                    id,
                                    display_name,
                                    description,
-                                   players_num)
+                                   players_num,
+                                   default_settings)
 
 class Game {
     const std::string CONFIG_FILE;

--- a/server/model/game_logic_manager.h
+++ b/server/model/game_logic_manager.h
@@ -11,14 +11,6 @@ namespace cavoke::server::model {
 class GameLogicManager {
     std::shared_ptr<GamesStorage> m_games_storage;
 
-    struct InitSettings {
-        json settings;
-        std::vector<int> occupied_positions;
-    };
-    NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(InitSettings,
-                                       settings,
-                                       occupied_positions);
-
     std::string invoke_logic(const Game &game, const std::string &input);
 
 public:
@@ -28,10 +20,17 @@ public:
         int player_id;
         std::string move;
         std::string global_state;
-
-        [[nodiscard]] Json::Value to_json() const;
     };
-    NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(GameMove, player_id, move, global_state);
+
+    struct InitSettings {
+        json settings;
+        std::vector<int> occupied_positions;
+    };
+
+    struct ValidationResult {
+        bool success;
+        std::string message;
+    };
 
     bool validate_settings(const std::string &game_id,
                            const json &settings,
@@ -46,6 +45,17 @@ public:
     GameStateStorage::GameState send_move(const std::string &game_id,
                                           const GameMove &move);
 };
+
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(GameLogicManager::InitSettings,
+                                   settings,
+                                   occupied_positions);
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(GameLogicManager::GameMove,
+                                   player_id,
+                                   move,
+                                   global_state);
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(GameLogicManager::ValidationResult,
+                                   success,
+                                   message);
 
 }  // namespace cavoke::server::model
 

--- a/server/model/game_logic_manager.h
+++ b/server/model/game_logic_manager.h
@@ -11,6 +11,14 @@ namespace cavoke::server::model {
 class GameLogicManager {
     std::shared_ptr<GamesStorage> m_games_storage;
 
+    struct InitSettings {
+        json settings;
+        std::vector<int> occupied_positions;
+    };
+    NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(InitSettings,
+                                       settings,
+                                       occupied_positions);
+
     std::string invoke_logic(const Game &game, const std::string &input);
 
 public:
@@ -23,6 +31,17 @@ public:
 
         [[nodiscard]] Json::Value to_json() const;
     };
+    NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(GameMove, player_id, move, global_state);
+
+    bool validate_settings(const std::string &game_id,
+                           const json &settings,
+                           const std::vector<int> &occupied_positions,
+                           std::string &error_message);
+
+    GameStateStorage::GameState init_state(
+        const std::string &game_id,
+        const json &settings,
+        const std::vector<int> &occupied_positions);
 
     GameStateStorage::GameState send_move(const std::string &game_id,
                                           const GameMove &move);

--- a/server/model/game_state_storage.h
+++ b/server/model/game_state_storage.h
@@ -2,6 +2,7 @@
 #define CAVOKE_SERVER_GAME_STATE_STORAGE_H
 
 #include <map>
+#include <nlohmann/json.hpp>
 #include <optional>
 #include <string>
 #include <vector>
@@ -29,6 +30,12 @@ public:
 private:
     std::map<std::string, GameState> m_states;
 };
+
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(GameStateStorage::GameState,
+                                   is_terminal,
+                                   global_state,
+                                   players_state,
+                                   winners);
 
 }  // namespace cavoke::server::model
 

--- a/server/model/sessions/game_session.cpp
+++ b/server/model/sessions/game_session.cpp
@@ -93,3 +93,8 @@ std::vector<int> cavoke::server::model::GameSession::get_occupied_positions()
     }
     return result;
 }
+
+const cavoke::server::model::json &
+cavoke::server::model::GameSession::get_game_settings() const {
+    return m_game_settings;
+}

--- a/server/model/sessions/game_session.cpp
+++ b/server/model/sessions/game_session.cpp
@@ -7,7 +7,7 @@ cavoke::server::model::game_session_error::game_session_error(
 }
 cavoke::server::model::GameSession::GameSession(
     cavoke::server::model::GameConfig game_config,
-    std::optional<json> game_settings = {})
+    std::optional<json> game_settings)
     : id(drogon::utils::getUuid()),
       m_game_config(std::move(game_config)),
       m_invite_code(generate_invite_code()) {

--- a/server/model/sessions/game_session.cpp
+++ b/server/model/sessions/game_session.cpp
@@ -6,10 +6,16 @@ cavoke::server::model::game_session_error::game_session_error(
                             "cavoke/sessions") {
 }
 cavoke::server::model::GameSession::GameSession(
-    cavoke::server::model::GameConfig game_config)
+    cavoke::server::model::GameConfig game_config,
+    std::optional<json> game_settings = {})
     : id(drogon::utils::getUuid()),
       m_game_config(std::move(game_config)),
       m_invite_code(generate_invite_code()) {
+    if (game_settings.has_value()) {
+        m_game_settings = game_settings.value();
+    } else {
+        m_game_settings = m_game_config.default_settings;
+    }
 }
 /**
  * Adds given user to session.
@@ -77,4 +83,13 @@ std::string cavoke::server::model::GameSession::generate_invite_code() {
         c = dist(engine);
     }
     return res;
+}
+
+std::vector<int> cavoke::server::model::GameSession::get_occupied_positions()
+    const {
+    std::vector<int> result;
+    for (const auto &e : m_userid_to_playerid) {
+        result.push_back(e.right);
+    }
+    return result;
 }

--- a/server/model/sessions/game_session.h
+++ b/server/model/sessions/game_session.h
@@ -18,7 +18,7 @@ struct game_session_error : cavoke_base_exception {
 };
 
 struct GameSession {
-    explicit GameSession(GameConfig game_config);
+    explicit GameSession(GameConfig game_config, std::optional<json> game_settings);
     GameSession() =
         default;  // FIXME: required by map in `sessions_storage.cpp`
 
@@ -39,11 +39,14 @@ struct GameSession {
 
     [[nodiscard]] GameSessionInfo get_session_info() const;
 
+    [[nodiscard]] std::vector<int> get_occupied_positions() const;
+
 private:
     std::string id;
     GameConfig m_game_config;
     std::string m_invite_code;
     boost::bimap<std::string, int> m_userid_to_playerid{};
+    json m_game_settings;
 
     static std::string generate_invite_code();
 };

--- a/server/model/sessions/game_session.h
+++ b/server/model/sessions/game_session.h
@@ -18,7 +18,8 @@ struct game_session_error : cavoke_base_exception {
 };
 
 struct GameSession {
-    explicit GameSession(GameConfig game_config, std::optional<json> game_settings);
+    explicit GameSession(GameConfig game_config,
+                         std::optional<json> game_settings);
     GameSession() =
         default;  // FIXME: required by map in `sessions_storage.cpp`
 
@@ -41,6 +42,8 @@ struct GameSession {
 
     [[nodiscard]] std::vector<int> get_occupied_positions() const;
 
+    [[nodiscard]] const json &get_game_settings() const;
+
 private:
     std::string id;
     GameConfig m_game_config;
@@ -48,6 +51,7 @@ private:
     boost::bimap<std::string, int> m_userid_to_playerid{};
     json m_game_settings;
 
+private:
     static std::string generate_invite_code();
 };
 

--- a/server/model/sessions/game_session.h
+++ b/server/model/sessions/game_session.h
@@ -19,7 +19,7 @@ struct game_session_error : cavoke_base_exception {
 
 struct GameSession {
     explicit GameSession(GameConfig game_config,
-                         std::optional<json> game_settings);
+                         std::optional<json> game_settings = {});
     GameSession() =
         default;  // FIXME: required by map in `sessions_storage.cpp`
 


### PR DESCRIPTION
Добавил поддержку конфигурации запуска игры.

Теперь в `config.json` нужно указывать поле `default_settings` -- JSON объект с конфигурацией по умолчанию.

Валидацию конфигурации, мне кажется, нужно поручить логике (альтернатива -- как-то задавать для каждого поля границы в конфиге, но, кажется, это менее гибко и более сложно). Теперь логика должна уметь выполянть несколько команд, поэтому я поменял протокол общения -- теперь сначала идет команда (`VALIDATE`, `INIT`, `MOVE`), а затем аргумент в формате JSON.

Вместе с конфигурацией командам `VALIDATE` и `INIT` передается список занятых позиций (подключенных).

Сейчас `VALIDATE` не используется, в качестве конфига всегда передается конфиг по умолчанию, вместо списка занятых позиций -- заглушка. 

В будущем, предлагаю такую схему работы: сессия делится на 2 стадии -- подключение и игра. На стадии подключения адми может редактировать конфиг. При изменении конфига/подключении игрока запускается `VALIDATE`, если логика говорит, что может стартовать, появляется кнопка "начать игру". После нажатия на нее, по текущим конфигу и подключенным игрокам генерируется состояние игры, начинается сама игра (можно делать ходы и т. д.) Новым игрокам подключаться уже нельзя.

Модифицировал крестики-нолики (логику) для поддержки доски 5x5 (размер доски задается в конфиге).