### PR TITLE
feature/client-settings

### DIFF
--- a/client/controllers/cavokeclientcontroller.cpp
+++ b/client/controllers/cavokeclientcontroller.cpp
@@ -111,16 +111,20 @@ CavokeClientController::CavokeClientController(QObject *parent)
 
     // Default settings initialization
     settings.setValue("player/nickname",
-                      settings.value("player/nickname", "Rzhaker"));
-    settings.setValue("network/host",
-                      settings.value("network/host", "No hosts?"));
+                      settings.value("player/nickname", "Guest"));
+    settings.setValue(
+        "network/host",
+        settings.value("network/host", NetworkManager::BASE_HOST));
+    
+    networkManager.changeHost(
+        QUrl::fromUserInput(settings.value("network/host").toString()));
 
     emit initSettingsValues(settings.value("player/nickname").toString(),
                             settings.value("network/host").toString());
 
     startView.show();
 
-    emit loadGamesList();
+//    emit loadGamesList(); Now it loads games list inside of changeHost
 }
 
 void CavokeClientController::showTestWindowView() {
@@ -284,4 +288,5 @@ void CavokeClientController::updateSettings(const QString &nickname,
                                             const QString &host) {
     settings.setValue("player/nickname", nickname);
     settings.setValue("network/host", host);
+    networkManager.changeHost(QUrl::fromUserInput(host));
 }

--- a/client/controllers/cavokeclientcontroller.cpp
+++ b/client/controllers/cavokeclientcontroller.cpp
@@ -8,7 +8,8 @@ CavokeClientController::CavokeClientController(QObject *parent)
       startView{},
       joinGameView{},
       settingsView{},
-      protoRoomView{} {
+      protoRoomView{},
+      settings{} {
     // startQml connection
     connect(&model, SIGNAL(startQmlApplication(CavokeQmlGameModel *)), this,
             SLOT(startQmlApplication(CavokeQmlGameModel *)));
@@ -101,6 +102,21 @@ CavokeClientController::CavokeClientController(QObject *parent)
             &protoRoomView, SLOT(updateValidationResult(ValidationResult)));
     connect(&protoRoomView, SIGNAL(createdGame()), &networkManager,
             SLOT(startSession()));
+
+    // settingsView actions
+    connect(this, SIGNAL(initSettingsValues(QString, QString)), &settingsView,
+            SLOT(initStartValues(QString, QString)));
+    connect(&settingsView, SIGNAL(updatedSettings(QString, QString)), this,
+            SLOT(updateSettings(QString, QString)));
+
+    // Default settings initialization
+    settings.setValue("player/nickname",
+                      settings.value("player/nickname", "Rzhaker"));
+    settings.setValue("network/host",
+                      settings.value("network/host", "No hosts?"));
+
+    emit initSettingsValues(settings.value("player/nickname").toString(),
+                            settings.value("network/host").toString());
 
     startView.show();
 
@@ -263,4 +279,9 @@ void CavokeClientController::creatingJoiningGameDone() {
     } else if (status == CreateJoinControllerStatus::JOINING) {
         status = CreateJoinControllerStatus::POLLING_JOIN;
     }
+}
+void CavokeClientController::updateSettings(const QString &nickname,
+                                            const QString &host) {
+    settings.setValue("player/nickname", nickname);
+    settings.setValue("network/host", host);
 }

--- a/client/controllers/cavokeclientcontroller.cpp
+++ b/client/controllers/cavokeclientcontroller.cpp
@@ -60,6 +60,7 @@ CavokeClientController::CavokeClientController(QObject *parent)
             SLOT(createGameStart(int)));
     connect(this, SIGNAL(createGameDownloaded()), this,
             SLOT(createGameSendRequest()));
+    connect(this, SIGNAL(clearScreens()), &gamesListView, SLOT(displayEmpty()));
 
     // both Join and Create gameView actions
     connect(&networkManager, SIGNAL(gotSessionInfo(SessionInfo)), this,
@@ -78,6 +79,7 @@ CavokeClientController::CavokeClientController(QObject *parent)
             SLOT(gotNewSelectedGame(GameInfo)));
     connect(&gamesListView, SIGNAL(requestedDownloadGame(int)), &model,
             SLOT(gotIndexToDownload(int)));
+    connect(this, SIGNAL(clearScreens()), &gamesListView, SLOT(displayEmpty()));
 
     // Download games list from server workflow
     connect(this, SIGNAL(loadGamesList()), &networkManager,
@@ -289,5 +291,6 @@ void CavokeClientController::updateSettings(const QString &nickname,
                                             const QString &host) {
     settings.setValue(PLAYER_NICKNAME, nickname);
     settings.setValue(NETWORK_HOST, host);
+    emit clearScreens();
     networkManager.changeHost(QUrl::fromUserInput(host));
 }

--- a/client/controllers/cavokeclientcontroller.cpp
+++ b/client/controllers/cavokeclientcontroller.cpp
@@ -115,7 +115,7 @@ CavokeClientController::CavokeClientController(QObject *parent)
     settings.setValue(
         "network/host",
         settings.value("network/host", NetworkManager::BASE_HOST));
-    
+
     networkManager.changeHost(
         QUrl::fromUserInput(settings.value("network/host").toString()));
 
@@ -124,7 +124,7 @@ CavokeClientController::CavokeClientController(QObject *parent)
 
     startView.show();
 
-//    emit loadGamesList(); Now it loads games list inside of changeHost
+    //    emit loadGamesList(); Now it loads games list inside of changeHost
 }
 
 void CavokeClientController::showTestWindowView() {

--- a/client/controllers/cavokeclientcontroller.cpp
+++ b/client/controllers/cavokeclientcontroller.cpp
@@ -109,22 +109,23 @@ CavokeClientController::CavokeClientController(QObject *parent)
     connect(&settingsView, SIGNAL(updatedSettings(QString, QString)), this,
             SLOT(updateSettings(QString, QString)));
 
-    // Default settings initialization
-    settings.setValue("player/nickname",
-                      settings.value("player/nickname", "Guest"));
-    settings.setValue(
-        "network/host",
-        settings.value("network/host", NetworkManager::BASE_HOST));
-
-    networkManager.changeHost(
-        QUrl::fromUserInput(settings.value("network/host").toString()));
-
-    emit initSettingsValues(settings.value("player/nickname").toString(),
-                            settings.value("network/host").toString());
+    defaultSettingsInitialization();
 
     startView.show();
+}
 
-    //    emit loadGamesList(); Now it loads games list inside of changeHost
+void CavokeClientController::defaultSettingsInitialization() {
+    settings.setValue(PLAYER_NICKNAME,
+                      settings.value(PLAYER_NICKNAME, DEFAULT_NICKNAME));
+    settings.setValue(
+        NETWORK_HOST,
+        settings.value(NETWORK_HOST, NetworkManager::DEFAULT_HOST));
+
+    networkManager.changeHost(
+        QUrl::fromUserInput(settings.value(NETWORK_HOST).toString()));
+
+    emit initSettingsValues(settings.value(PLAYER_NICKNAME).toString(),
+                            settings.value(NETWORK_HOST).toString());
 }
 
 void CavokeClientController::showTestWindowView() {
@@ -286,7 +287,7 @@ void CavokeClientController::creatingJoiningGameDone() {
 }
 void CavokeClientController::updateSettings(const QString &nickname,
                                             const QString &host) {
-    settings.setValue("player/nickname", nickname);
-    settings.setValue("network/host", host);
+    settings.setValue(PLAYER_NICKNAME, nickname);
+    settings.setValue(NETWORK_HOST, host);
     networkManager.changeHost(QUrl::fromUserInput(host));
 }

--- a/client/controllers/cavokeclientcontroller.h
+++ b/client/controllers/cavokeclientcontroller.h
@@ -40,6 +40,7 @@ signals:
     void createGameDownloaded();
     void joinGameDownloaded();
     void initSettingsValues(const QString &nickname, const QString &host);
+    void clearScreens();
 
 private slots:
     void startQmlApplication(CavokeQmlGameModel *);

--- a/client/controllers/cavokeclientcontroller.h
+++ b/client/controllers/cavokeclientcontroller.h
@@ -33,11 +33,13 @@ public slots:
     void showGamesListView();
     void showCreateGameView();
     void showSettingsView();
+    void updateSettings(const QString &nickname, const QString &host);
 
 signals:
     void loadGamesList();
     void createGameDownloaded();
     void joinGameDownloaded();
+    void initSettingsValues(const QString &nickname, const QString &host);
 
 private slots:
     void startQmlApplication(CavokeQmlGameModel *);
@@ -66,6 +68,7 @@ private:
     CavokeQmlGameModel *currentQmlGameModel = nullptr;
     CreateJoinControllerStatus status = CreateJoinControllerStatus::NOTHING;
     QString currentGameId;
+    QSettings settings;
 };
 
 #endif  // CAVOKECLIENTCONTROLLER_H

--- a/client/controllers/cavokeclientcontroller.h
+++ b/client/controllers/cavokeclientcontroller.h
@@ -69,6 +69,7 @@ private:
     CreateJoinControllerStatus status = CreateJoinControllerStatus::NOTHING;
     QString currentGameId;
     QSettings settings;
+    const static inline QUrl BASE_HOST{"https://develop.api.cavoke.wlko.me"};
 };
 
 #endif  // CAVOKECLIENTCONTROLLER_H

--- a/client/controllers/cavokeclientcontroller.h
+++ b/client/controllers/cavokeclientcontroller.h
@@ -56,6 +56,10 @@ private slots:
     void gotSessionInfo(const SessionInfo &sessionInfo);
 
 private:
+    void defaultSettingsInitialization();
+    const static inline QString PLAYER_NICKNAME{"player/nickname"};
+    const static inline QString NETWORK_HOST{"network/host"};
+    const static inline QString DEFAULT_NICKNAME{"Guest"};
     NetworkManager networkManager;
     CavokeClientModel model;
     TestWindowView testWindowView;
@@ -69,7 +73,6 @@ private:
     CreateJoinControllerStatus status = CreateJoinControllerStatus::NOTHING;
     QString currentGameId;
     QSettings settings;
-    const static inline QUrl BASE_HOST{"https://develop.api.cavoke.wlko.me"};
 };
 
 #endif  // CAVOKECLIENTCONTROLLER_H

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -4,7 +4,7 @@
 int main(int argc, char *argv[]) {
     QApplication a(argc, argv);
     QCoreApplication::setOrganizationName("Cavoke");
-    QCoreApplication::setOrganizationDomain("cavoke.alexkovrigin.me");
+    QCoreApplication::setOrganizationDomain("cavoke.wlko.me");
     QCoreApplication::setApplicationName("Cavoke");
     CavokeClientController c(&a);
     return a.exec();

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -3,6 +3,9 @@
 
 int main(int argc, char *argv[]) {
     QApplication a(argc, argv);
+    QCoreApplication::setOrganizationName("Cavoke");
+    QCoreApplication::setOrganizationDomain("cavoke.alexkovrigin.me");
+    QCoreApplication::setApplicationName("Cavoke");
     CavokeClientController c(&a);
     return a.exec();
 }

--- a/client/network_manager.cpp
+++ b/client/network_manager.cpp
@@ -239,5 +239,5 @@ void NetworkManager::stopValidationPolling() {
 }
 void NetworkManager::changeHost(const QUrl &newHost) {
     HOST = newHost;
-    getGamesList();  // Reload games list. Seems bad
+    getGamesList();
 }

--- a/client/network_manager.cpp
+++ b/client/network_manager.cpp
@@ -239,5 +239,5 @@ void NetworkManager::stopValidationPolling() {
 }
 void NetworkManager::changeHost(const QUrl &newHost) {
     HOST = newHost;
-    getGamesList(); // Reload games list. Seems bad
+    getGamesList();  // Reload games list. Seems bad
 }

--- a/client/network_manager.cpp
+++ b/client/network_manager.cpp
@@ -1,4 +1,5 @@
 #include "network_manager.h"
+#include <utility>
 
 NetworkManager::NetworkManager(QObject *parent) : manager(parent) {
     gamePollingTimer = new QTimer(this);
@@ -235,4 +236,8 @@ void NetworkManager::startValidationPolling() {
 
 void NetworkManager::stopValidationPolling() {
     validationPollingTimer->stop();
+}
+void NetworkManager::changeHost(const QUrl &newHost) {
+    HOST = newHost;
+    getGamesList(); // Reload games list. Seems bad
 }

--- a/client/network_manager.h
+++ b/client/network_manager.h
@@ -15,7 +15,9 @@
 struct NetworkManager : public QObject {
     Q_OBJECT
 public:
+    const static inline QUrl BASE_HOST{"https://develop.api.cavoke.wlko.me"};
     explicit NetworkManager(QObject *parent = nullptr);
+    void changeHost(const QUrl &newHost);   // Blocking
 
 public slots:
     void getHealth();
@@ -67,17 +69,7 @@ private:
     QTimer *validationPollingTimer = nullptr;
     QString sessionId;
     QUuid userId;
-    const static inline QUrl HOST{
-#ifdef MOCK
-        "https://764bbfca-c45a-46fc-9c79-11d9094b9ba8.mock.pstmn.io/"
-#else
-#ifdef REAL
-        "https://develop.api.cavoke.wlko.me"
-#else
-        "http://127.0.0.1:8080/"
-#endif
-#endif
-    };
+    QUrl HOST{BASE_HOST};
     const static inline QUrl HEALTH{"health"};  // FIXME: move to routes module
     const static inline QUrl GAMES_LIST{"games/list"};
     const static inline QUrl GAMES{"games/"};

--- a/client/network_manager.h
+++ b/client/network_manager.h
@@ -15,9 +15,9 @@
 struct NetworkManager : public QObject {
     Q_OBJECT
 public:
-    const static inline QUrl BASE_HOST{"https://develop.api.cavoke.wlko.me"};
+    const static inline QUrl DEFAULT_HOST{"https://develop.api.cavoke.wlko.me"};
     explicit NetworkManager(QObject *parent = nullptr);
-    void changeHost(const QUrl &newHost);  // Blocking
+    void changeHost(const QUrl &newHost);
 
 public slots:
     void getHealth();
@@ -69,7 +69,7 @@ private:
     QTimer *validationPollingTimer = nullptr;
     QString sessionId;
     QUuid userId;
-    QUrl HOST{BASE_HOST};
+    QUrl HOST{DEFAULT_HOST};
     const static inline QUrl HEALTH{"health"};  // FIXME: move to routes module
     const static inline QUrl GAMES_LIST{"games/list"};
     const static inline QUrl GAMES{"games/"};

--- a/client/network_manager.h
+++ b/client/network_manager.h
@@ -17,7 +17,7 @@ struct NetworkManager : public QObject {
 public:
     const static inline QUrl BASE_HOST{"https://develop.api.cavoke.wlko.me"};
     explicit NetworkManager(QObject *parent = nullptr);
-    void changeHost(const QUrl &newHost);   // Blocking
+    void changeHost(const QUrl &newHost);  // Blocking
 
 public slots:
     void getHealth();

--- a/client/views/creategameview.cpp
+++ b/client/views/creategameview.cpp
@@ -22,6 +22,7 @@ void CreateGameView::on_backButton_clicked() {
 }
 void CreateGameView::gotGamesListUpdate(
     const std::vector<GameInfo> &newGamesList) {
+    ui->gamesListComboBox->clear();
     for (const auto &gameInfo : newGamesList) {
         ui->gamesListComboBox->addItem(gameInfo.display_name);
     }

--- a/client/views/creategameview.cpp
+++ b/client/views/creategameview.cpp
@@ -30,7 +30,11 @@ void CreateGameView::gotGamesListUpdate(
     for (const auto &gameInfo : newGamesList) {
         ui->gamesListComboBox->addItem(gameInfo.display_name);
     }
-    ui->gamesListComboBox->setCurrentIndex(-1);
+    if (ui->gamesListComboBox->count() > 0) {
+        ui->gamesListComboBox->setCurrentIndex(0);
+    } else {
+        ui->gamesListComboBox->setCurrentIndex(-1);
+    }
 }
 
 void CreateGameView::gotNewSelectedGame(const GameInfo &gameInfo) {

--- a/client/views/creategameview.cpp
+++ b/client/views/creategameview.cpp
@@ -9,6 +9,10 @@ CreateGameView::CreateGameView(QWidget *parent)
 }
 
 void CreateGameView::repeaterCurrentIndexChanged(int index) {
+    if (index == -1) {
+        displayEmpty();
+        return;
+    }
     emit currentIndexChanged(index);
 }
 
@@ -26,7 +30,9 @@ void CreateGameView::gotGamesListUpdate(
     for (const auto &gameInfo : newGamesList) {
         ui->gamesListComboBox->addItem(gameInfo.display_name);
     }
+    ui->gamesListComboBox->setCurrentIndex(-1);
 }
+
 void CreateGameView::gotNewSelectedGame(const GameInfo &gameInfo) {
     ui->gameNameLabel->setText(gameInfo.display_name);
     ui->gameDescriptionTextBrowser->setText(gameInfo.description);
@@ -36,4 +42,10 @@ void CreateGameView::gotNewSelectedGame(const GameInfo &gameInfo) {
 void CreateGameView::on_createGameButton_clicked() {
     //    this->close();
     emit startedCreateGameRoutine(ui->gamesListComboBox->currentIndex());
+}
+void CreateGameView::displayEmpty() {
+    ui->gameNameLabel->clear();
+    ui->gameDescriptionTextBrowser->clear();
+    ui->playersAmountLabel->clear();
+    ui->createGameButton->setEnabled(false);
 }

--- a/client/views/creategameview.h
+++ b/client/views/creategameview.h
@@ -29,6 +29,7 @@ private slots:
     void repeaterCurrentIndexChanged(int index);
 
 private:
+    void displayEmpty();
     Ui::CreateGameView *ui;
 };
 

--- a/client/views/creategameview.h
+++ b/client/views/creategameview.h
@@ -17,6 +17,7 @@ public:
 public slots:
     void gotGamesListUpdate(const std::vector<GameInfo> &newGamesList);
     void gotNewSelectedGame(const GameInfo &gameInfo);
+    void displayEmpty();
 
 signals:
     void shownStartView();
@@ -29,7 +30,6 @@ private slots:
     void repeaterCurrentIndexChanged(int index);
 
 private:
-    void displayEmpty();
     Ui::CreateGameView *ui;
 };
 

--- a/client/views/gameslistview.cpp
+++ b/client/views/gameslistview.cpp
@@ -27,6 +27,7 @@ void GamesListView::on_downloadQmlButton_clicked() {
 
 void GamesListView::gotGamesListUpdate(
     const std::vector<GameInfo> &newGamesList) {
+    ui->gamesListWidget->clear();
     for (const auto &gameInfo : newGamesList) {
         ui->gamesListWidget->addItem(gameInfo.display_name);
     }

--- a/client/views/gameslistview.cpp
+++ b/client/views/gameslistview.cpp
@@ -9,6 +9,10 @@ GamesListView::GamesListView(QWidget *parent)
 }
 
 void GamesListView::repeaterCurrentIndexChanged(int index) {
+    if (index == -1) {
+        displayEmpty();
+        return;
+    }
     emit currentIndexChanged(index);
 }
 
@@ -31,6 +35,7 @@ void GamesListView::gotGamesListUpdate(
     for (const auto &gameInfo : newGamesList) {
         ui->gamesListWidget->addItem(gameInfo.display_name);
     }
+    //    ui->gamesListWidget->setCurrentIndex(-1); // Is needed? Tests required
 }
 
 void GamesListView::gotNewSelectedGame(const GameInfo &gameInfo) {
@@ -38,4 +43,10 @@ void GamesListView::gotNewSelectedGame(const GameInfo &gameInfo) {
     ui->gameDescriptionTextBrowser->setText(gameInfo.description);
     ui->playersAmountLabel->setText(QString::number(gameInfo.players_num));
     //    ui->createGameButton->setEnabled(true);
+}
+
+void GamesListView::displayEmpty() {
+    ui->gameNameLabel->clear();
+    ui->gameDescriptionTextBrowser->clear();
+    ui->playersAmountLabel->clear();
 }

--- a/client/views/gameslistview.h
+++ b/client/views/gameslistview.h
@@ -17,6 +17,7 @@ public:
 public slots:
     void gotGamesListUpdate(const std::vector<GameInfo> &newGamesList);
     void gotNewSelectedGame(const GameInfo &gameInfo);
+    void displayEmpty();
 
 signals:
     void shownStartView();
@@ -29,7 +30,6 @@ private slots:
     void repeaterCurrentIndexChanged(int index);
 
 private:
-    void displayEmpty();
     Ui::GamesListView *ui;
 };
 

--- a/client/views/gameslistview.h
+++ b/client/views/gameslistview.h
@@ -29,6 +29,7 @@ private slots:
     void repeaterCurrentIndexChanged(int index);
 
 private:
+    void displayEmpty();
     Ui::GamesListView *ui;
 };
 

--- a/client/views/settingsview.cpp
+++ b/client/views/settingsview.cpp
@@ -23,4 +23,6 @@ void SettingsView::on_backButton_clicked() {
 void SettingsView::on_updateSettingsButton_clicked() {
     emit updatedSettings(ui->nicknameInput->text(),
                          ui->serverAddressInput->text());
+    this->close();
+    emit shownStartView();
 }

--- a/client/views/settingsview.cpp
+++ b/client/views/settingsview.cpp
@@ -10,7 +10,17 @@ SettingsView::~SettingsView() {
     delete ui;
 }
 
+void SettingsView::initStartValues(const QString &nickname,
+                                   const QString &host) {
+    ui->nicknameInput->setText(nickname);
+    ui->serverAddressInput->setText(host);
+}
+
 void SettingsView::on_backButton_clicked() {
     this->close();
     emit shownStartView();
+}
+void SettingsView::on_updateSettingsButton_clicked() {
+    emit updatedSettings(ui->nicknameInput->text(),
+                         ui->serverAddressInput->text());
 }

--- a/client/views/settingsview.h
+++ b/client/views/settingsview.h
@@ -13,11 +13,16 @@ public:
     explicit SettingsView(QWidget *parent = nullptr);
     ~SettingsView();
 
+public slots:
+    void initStartValues(const QString &nickname, const QString &host);
+
 signals:
     void shownStartView();
+    void updatedSettings(const QString &nickname, const QString &host);
 
 private slots:
     void on_backButton_clicked();
+    void on_updateSettingsButton_clicked();
 
 private:
     Ui::SettingsView *ui;

--- a/client/views/settingsview.ui
+++ b/client/views/settingsview.ui
@@ -26,31 +26,140 @@
    <string>Cavoke</string>
   </property>
   <widget class="QWidget" name="centralwidget">
-   <widget class="QPushButton" name="backButton">
+   <widget class="QGroupBox" name="groupBox">
     <property name="geometry">
      <rect>
-      <x>40</x>
-      <y>480</y>
-      <width>90</width>
-      <height>32</height>
+      <x>9</x>
+      <y>9</y>
+      <width>782</width>
+      <height>541</height>
      </rect>
     </property>
-    <property name="text">
-     <string>Back</string>
+    <property name="title">
+     <string/>
     </property>
-   </widget>
-   <widget class="QLabel" name="label">
-    <property name="geometry">
-     <rect>
-      <x>200</x>
-      <y>60</y>
-      <width>291</width>
-      <height>71</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Settings. Empty.</string>
-    </property>
+    <widget class="QPushButton" name="backButton">
+     <property name="geometry">
+      <rect>
+       <x>1</x>
+       <y>4</y>
+       <width>61</width>
+       <height>31</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Back</string>
+     </property>
+    </widget>
+    <widget class="QWidget" name="gridLayoutWidget">
+     <property name="geometry">
+      <rect>
+       <x>59</x>
+       <y>29</y>
+       <width>661</width>
+       <height>481</height>
+      </rect>
+     </property>
+     <layout class="QGridLayout" name="gridLayout" rowstretch="3,2,1,1,2" columnstretch="1,3">
+      <property name="leftMargin">
+       <number>10</number>
+      </property>
+      <property name="rightMargin">
+       <number>10</number>
+      </property>
+      <item row="1" column="0">
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Nickname:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" colspan="2">
+       <widget class="QLabel" name="label">
+        <property name="font">
+         <font>
+          <pointsize>16</pointsize>
+         </font>
+        </property>
+        <property name="text">
+         <string>SETTINGS</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLineEdit" name="nicknameInput">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Server address:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QLineEdit" name="serverAddressInput">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="2">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <property name="leftMargin">
+         <number>200</number>
+        </property>
+        <property name="topMargin">
+         <number>20</number>
+        </property>
+        <property name="rightMargin">
+         <number>200</number>
+        </property>
+        <property name="bottomMargin">
+         <number>20</number>
+        </property>
+        <item>
+         <widget class="QPushButton" name="updateSettingsButton">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Ignored">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Update settings</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
    </widget>
   </widget>
   <widget class="QMenuBar" name="menubar">


### PR DESCRIPTION
Добавлены настройки клиента:

1. Обновлён экран Settings: Теперь он в едином стиле с остальными рабочими экранами, а так же на нём можно ввести ник и адрес хоста. (Ник пока никуда не используется)
2. Введённые параметры сохраняются (точное место зависит от платформы, Qt обо всём само заботится) между запусками.
3. Введённый адрес хоста используется NetworkManager-ом. При нажатии на кнопку сохранения настроек происходит повторная загрузка по указанному адресу (В случае, если указанное адресом не является, то просто ничего не изменится, просто связи с сервером не будет).
4. Никакой верификации полей нет, увы. Но вроде пока и не особо нужна.

Closes #95 