### PR TITLE
feature/client-choosing-role

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable(cavoke_client
         views/gameslistview.cpp
         views/protoroomview.cpp
         entities/gameinfo.cpp
+        entities/role.cpp
         entities/sessioninfo.cpp
         entities/validationresult.cpp
         cache_manager.cpp

--- a/client/controllers/cavokeclientcontroller.cpp
+++ b/client/controllers/cavokeclientcontroller.cpp
@@ -123,6 +123,8 @@ CavokeClientController::CavokeClientController(QObject *parent)
         SIGNAL(createdAvailableRolesList(std::vector<std::pair<QString, int>>)),
         &protoRoomView,
         SLOT(gotRolesListUpdate(std::vector<std::pair<QString, int>>)));
+    connect(&protoRoomView, SIGNAL(newRoleChosen(int)), &networkManager,
+            SLOT(changeRoleInSession(int)));
 
     // settingsView actions
     connect(this, SIGNAL(initSettingsValues(QString, QString)), &settingsView,
@@ -334,11 +336,12 @@ void CavokeClientController::collectListOfAvailableRoles() {
         }
     }
     std::vector<std::pair<QString, int>> availableRoles;
+    availableRoles.emplace_back(currentGameInfo.role_names[ourRole],
+                                ourRole);  // Now first.
     for (int i = 0; i < currentGameInfo.players_num; ++i) {
         if (isFree[i]) {
             availableRoles.emplace_back(currentGameInfo.role_names[i], i);
         }
     }
-    availableRoles.emplace_back(currentGameInfo.role_names[ourRole], ourRole);
     emit createdAvailableRolesList(availableRoles);
 }

--- a/client/controllers/cavokeclientcontroller.cpp
+++ b/client/controllers/cavokeclientcontroller.cpp
@@ -110,6 +110,10 @@ CavokeClientController::CavokeClientController(QObject *parent)
             &protoRoomView, SLOT(updateValidationResult(ValidationResult)));
     connect(&protoRoomView, SIGNAL(createdGame()), &networkManager,
             SLOT(startSession()));
+    connect(&protoRoomView, SIGNAL(leftRoom()), &networkManager, SLOT(stopGamePolling()));
+    connect(&protoRoomView, SIGNAL(leftRoom()), &networkManager, SLOT(stopSessionPolling()));
+    connect(&protoRoomView, SIGNAL(leftRoom()), &networkManager, SLOT(stopValidationPolling()));
+    connect(&protoRoomView, SIGNAL(leftRoom()), &networkManager, SLOT(leaveSession()));
 
     // settingsView actions
     connect(this, SIGNAL(initSettingsValues(QString, QString)), &settingsView,

--- a/client/controllers/cavokeclientcontroller.cpp
+++ b/client/controllers/cavokeclientcontroller.cpp
@@ -104,12 +104,7 @@ CavokeClientController::CavokeClientController(QObject *parent)
             &protoRoomView, SLOT(updateValidationResult(ValidationResult)));
     connect(&protoRoomView, SIGNAL(createdGame()), &networkManager,
             SLOT(startSession()));
-    connect(&protoRoomView, SIGNAL(leftRoom()), &networkManager,
-            SLOT(stopGamePolling()));
-    connect(&protoRoomView, SIGNAL(leftRoom()), &networkManager,
-            SLOT(stopSessionPolling()));
-    connect(&protoRoomView, SIGNAL(leftRoom()), &networkManager,
-            SLOT(stopValidationPolling()));
+    connect(&protoRoomView, SIGNAL(leftRoom()), this, SLOT(leftSession()));
     connect(&protoRoomView, SIGNAL(leftRoom()), &networkManager,
             SLOT(leaveSession()));
     connect(this, SIGNAL(createdAvailableRolesList(std::vector<Role>)),
@@ -146,12 +141,18 @@ void CavokeClientController::showTestWindowView() {
     testWindowView.show();
 }
 
-void CavokeClientController::showStartView() {
-    startView.show();
+void CavokeClientController::leftSession() {
+    networkManager.stopGamePolling();
+    networkManager.stopSessionPolling();
+    networkManager.stopValidationPolling();
     qmlDownloadStatus = QMLDownloadStatus::NOT_STARTED;
     hostGuestStatus = HostGuestStatus::NOT_IN;
     currentGameInfo = GameInfo();
     currentSessionInfo = SessionInfo();
+}
+
+void CavokeClientController::showStartView() {
+    startView.show();
 }
 
 void CavokeClientController::showJoinGameView() {
@@ -218,9 +219,10 @@ void CavokeClientController::startLoadedQml() {
 }
 
 void CavokeClientController::stopQml() {
+    networkManager.stopGamePolling();
+    leftSession();
     startView.show();
     currentQmlGameModel->deleteLater();
-    networkManager.stopGamePolling();
 }
 
 void CavokeClientController::unpackDownloadedQml(QFile *file,

--- a/client/controllers/cavokeclientcontroller.cpp
+++ b/client/controllers/cavokeclientcontroller.cpp
@@ -112,11 +112,8 @@ CavokeClientController::CavokeClientController(QObject *parent)
             SLOT(stopValidationPolling()));
     connect(&protoRoomView, SIGNAL(leftRoom()), &networkManager,
             SLOT(leaveSession()));
-    connect(
-        this,
-        SIGNAL(createdAvailableRolesList(std::vector<std::pair<QString, int>>)),
-        &protoRoomView,
-        SLOT(gotRolesListUpdate(std::vector<std::pair<QString, int>>)));
+    connect(this, SIGNAL(createdAvailableRolesList(std::vector<Role>)),
+            &protoRoomView, SLOT(gotRolesListUpdate(std::vector<Role>)));
     connect(&protoRoomView, SIGNAL(newRoleChosen(int)), &networkManager,
             SLOT(changeRoleInSession(int)));
 
@@ -313,7 +310,7 @@ void CavokeClientController::collectListOfAvailableRoles() {
             ourRole = player.player_id;
         }
     }
-    std::vector<std::pair<QString, int>> availableRoles;
+    std::vector<Role> availableRoles;
     availableRoles.emplace_back(currentGameInfo.role_names[ourRole],
                                 ourRole);  // Now first.
     for (int i = 0; i < currentGameInfo.players_num; ++i) {

--- a/client/controllers/cavokeclientcontroller.h
+++ b/client/controllers/cavokeclientcontroller.h
@@ -42,8 +42,7 @@ signals:
     void setGameName(const QString &gameName);
     void initSettingsValues(const QString &nickname, const QString &host);
     void clearScreens();
-    void createdAvailableRolesList(
-        const std::vector<std::pair<QString, int>> &availableRoles);
+    void createdAvailableRolesList(const std::vector<Role> &availableRoles);
 
 private slots:
     void startQmlApplication(CavokeQmlGameModel *);

--- a/client/controllers/cavokeclientcontroller.h
+++ b/client/controllers/cavokeclientcontroller.h
@@ -39,6 +39,8 @@ signals:
     void loadGamesList();
     void createGameDownloaded();
     void joinGameDownloaded();
+    void gettingGameInfo(const QString &gameId);
+    void setGameName(const QString &gameName);
     void initSettingsValues(const QString &nickname, const QString &host);
     void clearScreens();
 
@@ -52,6 +54,7 @@ private slots:
     void createGameStart(int gameIndex);
     void joinGameStart(const QString &inviteCode);
     void downloadCurrentGame();
+    void gotCurrentGameInfo(const GameInfo &gameInfo);
     void creatingJoiningGameDone();
     void createGameSendRequest();
     void gotSessionInfo(const SessionInfo &sessionInfo);
@@ -71,8 +74,9 @@ private:
     SettingsView settingsView;
     ProtoRoomView protoRoomView;
     CavokeQmlGameModel *currentQmlGameModel = nullptr;
+    SessionInfo currentSessionInfo;
+    GameInfo currentGameInfo;
     CreateJoinControllerStatus status = CreateJoinControllerStatus::NOTHING;
-    QString currentGameId;
     QSettings settings;
 };
 

--- a/client/controllers/cavokeclientcontroller.h
+++ b/client/controllers/cavokeclientcontroller.h
@@ -15,13 +15,15 @@
 #include "testwindowview.h"
 
 class CavokeClientController : public QObject {
-    enum class CreateJoinControllerStatus {
-        NOTHING,
-        CREATING,
-        JOINING,
-        POLLING_CREATE,
-        POLLING_JOIN
-    };
+    //    enum class CreateJoinControllerStatus {
+    //        NOTHING,
+    //        CREATING,
+    //        JOINING,
+    //        POLLING_CREATE,
+    //        POLLING_JOIN
+    //    };
+    enum class QMLDownloadStatus { NOT_STARTED, DOWNLOADING, DOWNLOADED };
+    enum class HostGuestStatus { NOT_IN, HOST, GUEST };
     Q_OBJECT
 public:
     explicit CavokeClientController(QObject *parent = nullptr);
@@ -37,9 +39,6 @@ public slots:
 
 signals:
     void loadGamesList();
-    void createGameDownloaded();
-    void joinGameDownloaded();
-    void gettingGameInfo(const QString &gameId);
     void setGameName(const QString &gameName);
     void initSettingsValues(const QString &nickname, const QString &host);
     void clearScreens();
@@ -55,12 +54,11 @@ private slots:
     void unpackDownloadedQml(QFile *file, const QString &gameId);
     void createGameStart(int gameIndex);
     void joinGameStart(const QString &inviteCode);
-    void downloadCurrentGame();
     void gotCurrentGameInfo(const GameInfo &gameInfo);
-    void creatingJoiningGameDone();
-    void createGameSendRequest();
     void gotSessionInfo(const SessionInfo &sessionInfo);
     void collectListOfAvailableRoles();
+    void becomeHost();
+    void becomeGuest();
 
 private:
     void defaultSettingsInitialization();
@@ -79,7 +77,8 @@ private:
     CavokeQmlGameModel *currentQmlGameModel = nullptr;
     SessionInfo currentSessionInfo;
     GameInfo currentGameInfo;
-    CreateJoinControllerStatus status = CreateJoinControllerStatus::NOTHING;
+    QMLDownloadStatus qmlDownloadStatus = QMLDownloadStatus::NOT_STARTED;
+    HostGuestStatus hostGuestStatus = HostGuestStatus::NOT_IN;
     QSettings settings;
 };
 

--- a/client/controllers/cavokeclientcontroller.h
+++ b/client/controllers/cavokeclientcontroller.h
@@ -58,6 +58,7 @@ private slots:
     void collectListOfAvailableRoles();
     void becomeHost();
     void becomeGuest();
+    void leftSession();
 
 private:
     void defaultSettingsInitialization();

--- a/client/controllers/cavokeclientcontroller.h
+++ b/client/controllers/cavokeclientcontroller.h
@@ -43,6 +43,8 @@ signals:
     void setGameName(const QString &gameName);
     void initSettingsValues(const QString &nickname, const QString &host);
     void clearScreens();
+    void createdAvailableRolesList(
+        const std::vector<std::pair<QString, int>> &availableRoles);
 
 private slots:
     void startQmlApplication(CavokeQmlGameModel *);
@@ -58,6 +60,7 @@ private slots:
     void creatingJoiningGameDone();
     void createGameSendRequest();
     void gotSessionInfo(const SessionInfo &sessionInfo);
+    void collectListOfAvailableRoles();
 
 private:
     void defaultSettingsInitialization();

--- a/client/entities/gameinfo.cpp
+++ b/client/entities/gameinfo.cpp
@@ -26,11 +26,8 @@ void GameInfo::read(const QJsonObject &json) {
         players_num = json[PLAYERS_NUM].toInt();
 
     if (json.contains(ROLE_NAMES) && json[ROLE_NAMES].isArray()) {
-        for (auto obj : json[ROLE_NAMES].toArray()) {
-            // I failed to use std::transform with json[ROLE_NAMES].toArray()
-            // cppcheck-suppress useStlAlgorithm
-            role_names.push_back(obj.toString());
-        }
+        auto objects = json[ROLE_NAMES].toArray();
+        std::transform(objects.begin(), objects.end(), std::back_inserter(role_names), [](const QJsonValueRef &obj){return obj.toString();});
     }
 }
 void GameInfo::write(QJsonObject &json) const {

--- a/client/entities/gameinfo.cpp
+++ b/client/entities/gameinfo.cpp
@@ -4,28 +4,37 @@ GameInfo::GameInfo() = default;
 GameInfo::GameInfo(QString _id,
                    QString _display_name,
                    QString _description,
-                   int _players_num)
+                   int _players_num,
+                   QVector<QString> _role_names)
     : id(std::move(_id)),
       display_name(std::move(_display_name)),
       description(std::move(_description)),
-      players_num(_players_num) {
+      players_num(_players_num),
+      role_names(std::move(_role_names)) {
 }
 void GameInfo::read(const QJsonObject &json) {
-    if (json.contains("id") && json["id"].isString())
-        id = json["id"].toString();
+    if (json.contains(ID) && json[ID].isString())
+        id = json[ID].toString();
 
-    if (json.contains("display_name") && json["display_name"].isString())
-        display_name = json["display_name"].toString();
+    if (json.contains(DISPLAY_NAME) && json[DISPLAY_NAME].isString())
+        display_name = json[DISPLAY_NAME].toString();
 
-    if (json.contains("description") && json["description"].isString())
-        description = json["description"].toString();
+    if (json.contains(DESCRIPTION) && json[DESCRIPTION].isString())
+        description = json[DESCRIPTION].toString();
 
-    if (json.contains("players_num") && json["players_num"].isDouble())
-        players_num = json["players_num"].toInt();
+    if (json.contains(PLAYERS_NUM) && json[PLAYERS_NUM].isDouble())
+        players_num = json[PLAYERS_NUM].toInt();
+
+    if (json.contains(ROLE_NAMES) && json[ROLE_NAMES].isArray()) {
+        for (auto obj : json[ROLE_NAMES].toArray()) {
+            role_names.push_back(obj.toString());
+        }
+    }
 }
 void GameInfo::write(QJsonObject &json) const {
     json["id"] = id;
-    json["display_name"] = display_name;
-    json["description"] = description;
-    json["players_num"] = players_num;
+    json[DISPLAY_NAME] = display_name;
+    json[DESCRIPTION] = description;
+    json[PLAYERS_NUM] = players_num;
+    // Actually, write is not used
 }

--- a/client/entities/gameinfo.cpp
+++ b/client/entities/gameinfo.cpp
@@ -27,12 +27,14 @@ void GameInfo::read(const QJsonObject &json) {
 
     if (json.contains(ROLE_NAMES) && json[ROLE_NAMES].isArray()) {
         for (auto obj : json[ROLE_NAMES].toArray()) {
+            // I failed to use std::transform with json[ROLE_NAMES].toArray()
+            // cppcheck-suppress useStlAlgorithm
             role_names.push_back(obj.toString());
         }
     }
 }
 void GameInfo::write(QJsonObject &json) const {
-    json["id"] = id;
+    json[ID] = id;
     json[DISPLAY_NAME] = display_name;
     json[DESCRIPTION] = description;
     json[PLAYERS_NUM] = players_num;

--- a/client/entities/gameinfo.cpp
+++ b/client/entities/gameinfo.cpp
@@ -27,7 +27,9 @@ void GameInfo::read(const QJsonObject &json) {
 
     if (json.contains(ROLE_NAMES) && json[ROLE_NAMES].isArray()) {
         auto objects = json[ROLE_NAMES].toArray();
-        std::transform(objects.begin(), objects.end(), std::back_inserter(role_names), [](const QJsonValueRef &obj){return obj.toString();});
+        std::transform(objects.begin(), objects.end(),
+                       std::back_inserter(role_names),
+                       [](const QJsonValueRef &obj) { return obj.toString(); });
     }
 }
 void GameInfo::write(QJsonObject &json) const {

--- a/client/entities/gameinfo.h
+++ b/client/entities/gameinfo.h
@@ -1,9 +1,9 @@
 #ifndef CAVOKE_CLIENT_GAMEINFO_H
 #define CAVOKE_CLIENT_GAMEINFO_H
 
+#include <QtCore/QJsonArray>
 #include <QtCore/QJsonObject>
 #include <QtCore/QString>
-#include <QtCore/QJsonArray>
 struct GameInfo {
 public:
     GameInfo();

--- a/client/entities/gameinfo.h
+++ b/client/entities/gameinfo.h
@@ -3,13 +3,15 @@
 
 #include <QtCore/QJsonObject>
 #include <QtCore/QString>
+#include <QtCore/QJsonArray>
 struct GameInfo {
 public:
     GameInfo();
     GameInfo(QString _id,
              QString _display_name,
              QString _description,
-             int _players_num);
+             int _players_num,
+             QVector<QString> _role_names);
 
     void read(const QJsonObject &json);
     void write(QJsonObject &json) const;
@@ -18,6 +20,14 @@ public:
     QString display_name;
     QString description;
     int players_num = 0;
+    QVector<QString> role_names;
+
+private:
+    static inline const QString ID = "id";
+    static inline const QString DISPLAY_NAME = "display_name";
+    static inline const QString DESCRIPTION = "description";
+    static inline const QString PLAYERS_NUM = "players_num";
+    static inline const QString ROLE_NAMES = "role_names";
 };
 
 #endif  // CAVOKE_CLIENT_GAMEINFO_H

--- a/client/entities/role.cpp
+++ b/client/entities/role.cpp
@@ -1,0 +1,4 @@
+#include "role.h"
+
+Role::Role(QString _name, int _id) : name(std::move(_name)), id(_id) {
+}

--- a/client/entities/role.h
+++ b/client/entities/role.h
@@ -1,0 +1,12 @@
+#ifndef CAVOKE_ROLE_H
+#define CAVOKE_ROLE_H
+
+#include <QString>
+struct Role {
+    QString name = "";
+    int id = 0;
+
+    Role(QString _name, int _id);
+};
+
+#endif  // CAVOKE_ROLE_H

--- a/client/entities/sessioninfo.cpp
+++ b/client/entities/sessioninfo.cpp
@@ -5,11 +5,13 @@ SessionInfo::SessionInfo(QString _session_id,
                          QString _game_id,
                          int _status,
                          QString _invite_code,
+                         QString _host_id,
                          QVector<Player> _players)
     : session_id(std::move(_session_id)),
       game_id(std::move(_game_id)),
       status(_status),
       invite_code(std::move(_invite_code)),
+      host_id(std::move(_host_id)),
       players(std::move(_players)) {
 }
 void SessionInfo::read(const QJsonObject &json) {
@@ -27,6 +29,10 @@ void SessionInfo::read(const QJsonObject &json) {
 
     if (json.contains(INVITE_CODE) && json[INVITE_CODE].isString()) {
         invite_code = json[INVITE_CODE].toString();
+    }
+
+    if (json.contains(HOST_ID) && json[HOST_ID].isString()) {
+        host_id = json[HOST_ID].toString();
     }
 
     if (json.contains(PLAYERS) && json[PLAYERS].isArray()) {

--- a/client/entities/sessioninfo.h
+++ b/client/entities/sessioninfo.h
@@ -13,6 +13,7 @@ public:
                 QString _game_id,
                 int _status,
                 QString _invite_code,
+                QString _host_id,
                 QVector<Player> _players);
 
     void read(const QJsonObject &json);
@@ -23,13 +24,16 @@ public:
     // FIXME: next field should be an enum
     int status = 0;  // 0 -- NOT STARTED, 1 -- RUNNING, 2 -- FINISHED
     QString invite_code;
+    QString host_id;
     QVector<Player> players;
+    bool isHost = false;
 
 private:
     static inline const QString SESSION_ID = "session_id";
     static inline const QString GAME_ID = "game_id";
     static inline const QString STATUS = "status";
     static inline const QString INVITE_CODE = "invite_code";
+    static inline const QString HOST_ID = "host_id";
     static inline const QString PLAYERS = "players";
 };
 

--- a/client/models/cavokeclientmodel.cpp
+++ b/client/models/cavokeclientmodel.cpp
@@ -24,7 +24,7 @@ void CavokeClientModel::updateGamesList(const QJsonArray &newGamesList) {
                    });
     gamesList = std::move(got_from);
 
-    if (!gamesList.empty()) {
+    if (!newGamesList.empty()) {
         qDebug() << "First In Model: " << gamesList[0].id;
     }
     emit gamesListUpdated(gamesList);

--- a/client/models/cavokeclientmodel.cpp
+++ b/client/models/cavokeclientmodel.cpp
@@ -41,8 +41,8 @@ void CavokeClientModel::gotIndexToDownload(int index) {
     gotGameIdToDownload(gamesList[index].id);
 }
 
-QString CavokeClientModel::getGameIdByIndex(int index) {
-    return gamesList[index].id;
+GameInfo CavokeClientModel::getGameByIndex(int index) {
+    return gamesList[index];
 }
 
 void CavokeClientModel::gotGameIdToDownload(const QString &gameId) {

--- a/client/models/cavokeclientmodel.h
+++ b/client/models/cavokeclientmodel.h
@@ -10,7 +10,7 @@ class CavokeClientModel : public QObject {
 
 public:
     explicit CavokeClientModel(QObject *parent = nullptr);
-    QString getGameIdByIndex(int index);  // FIXME: oh no, cringe
+    GameInfo getGameByIndex(int index);  // FIXME: oh no, cringe
 public slots:
     void loadQmlGame(const QString &gameId);
     void updateGamesList(const QJsonArray &newGamesList);

--- a/client/network_manager.cpp
+++ b/client/network_manager.cpp
@@ -238,6 +238,20 @@ void NetworkManager::leaveSession() {
             [reply, this]() { gotPostResponse(reply); });
 }
 
+void NetworkManager::changeRoleInSession(int newRole) {
+    QUrl route =
+        HOST.resolved(SESSIONS).resolved(sessionId + "/").resolved(CHANGE_ROLE);
+    route.setQuery({{"user_id", userId.toString(QUuid::WithoutBraces)},
+                    {"new_role", QString::number(newRole)}});
+    qDebug() << route.toString();
+    auto request = QNetworkRequest(route);
+    request.setHeader(QNetworkRequest::KnownHeaders::ContentTypeHeader,
+                      "application/json");
+    auto reply = manager.post(request, "{}");
+    connect(reply, &QNetworkReply::finished, this,
+            [reply, this]() { gotPostResponse(reply); });
+}
+
 void NetworkManager::startGamePolling() {
     gamePollingTimer->start();
 }
@@ -263,6 +277,6 @@ void NetworkManager::changeHost(const QUrl &newHost) {
     HOST = newHost;
     getGamesList();
 }
-const QString NetworkManager::getUserId() {
+QString NetworkManager::getUserId() {
     return userId.toString(QUuid::WithoutBraces);
 }

--- a/client/network_manager.cpp
+++ b/client/network_manager.cpp
@@ -263,3 +263,6 @@ void NetworkManager::changeHost(const QUrl &newHost) {
     HOST = newHost;
     getGamesList();
 }
+const QString NetworkManager::getUserId() {
+    return userId.toString(QUuid::WithoutBraces);
+}

--- a/client/network_manager.cpp
+++ b/client/network_manager.cpp
@@ -125,7 +125,7 @@ void NetworkManager::gotSession(QNetworkReply *reply) {
     QByteArray answer = reply->readAll();
     reply->close();
     reply->deleteLater();
-    qDebug() << answer;
+//    qDebug() << answer;
 
     SessionInfo sessionInfo;
     sessionInfo.read(QJsonDocument::fromJson(answer).object());
@@ -180,7 +180,7 @@ void NetworkManager::validateSession() {
     QUrl route =
         HOST.resolved(SESSIONS).resolved(sessionId + "/").resolved(VALIDATE);
     route.setQuery({{"user_id", userId.toString(QUuid::WithoutBraces)}});
-    qDebug() << route.toString();
+//    qDebug() << route.toString();
     auto request = QNetworkRequest(route);
     request.setHeader(QNetworkRequest::KnownHeaders::ContentTypeHeader,
                       "application/json");
@@ -193,7 +193,7 @@ void NetworkManager::gotValidatedSession(QNetworkReply *reply) {
     QByteArray answer = reply->readAll();
     reply->close();
     reply->deleteLater();
-    qDebug() << answer;
+//    qDebug() << answer;
 
     ValidationResult validationResult;
     validationResult.read(QJsonDocument::fromJson(answer).object());
@@ -205,7 +205,7 @@ void NetworkManager::getSessionInfo() {
     QUrl route =
         HOST.resolved(SESSIONS).resolved(sessionId + "/").resolved(GET_INFO);
     route.setQuery({{"user_id", userId.toString(QUuid::WithoutBraces)}});
-    qDebug() << route.toString();
+//    qDebug() << route.toString();
     auto request = QNetworkRequest(route);
     auto reply = manager.get(request);
     connect(reply, &QNetworkReply::finished, this,

--- a/client/network_manager.cpp
+++ b/client/network_manager.cpp
@@ -125,7 +125,7 @@ void NetworkManager::gotSession(QNetworkReply *reply) {
     QByteArray answer = reply->readAll();
     reply->close();
     reply->deleteLater();
-//    qDebug() << answer;
+    //    qDebug() << answer;
 
     SessionInfo sessionInfo;
     sessionInfo.read(QJsonDocument::fromJson(answer).object());
@@ -180,7 +180,7 @@ void NetworkManager::validateSession() {
     QUrl route =
         HOST.resolved(SESSIONS).resolved(sessionId + "/").resolved(VALIDATE);
     route.setQuery({{"user_id", userId.toString(QUuid::WithoutBraces)}});
-//    qDebug() << route.toString();
+    //    qDebug() << route.toString();
     auto request = QNetworkRequest(route);
     request.setHeader(QNetworkRequest::KnownHeaders::ContentTypeHeader,
                       "application/json");
@@ -193,7 +193,7 @@ void NetworkManager::gotValidatedSession(QNetworkReply *reply) {
     QByteArray answer = reply->readAll();
     reply->close();
     reply->deleteLater();
-//    qDebug() << answer;
+    //    qDebug() << answer;
 
     ValidationResult validationResult;
     validationResult.read(QJsonDocument::fromJson(answer).object());
@@ -205,7 +205,7 @@ void NetworkManager::getSessionInfo() {
     QUrl route =
         HOST.resolved(SESSIONS).resolved(sessionId + "/").resolved(GET_INFO);
     route.setQuery({{"user_id", userId.toString(QUuid::WithoutBraces)}});
-//    qDebug() << route.toString();
+    //    qDebug() << route.toString();
     auto request = QNetworkRequest(route);
     auto reply = manager.get(request);
     connect(reply, &QNetworkReply::finished, this,

--- a/client/network_manager.cpp
+++ b/client/network_manager.cpp
@@ -183,7 +183,7 @@ void NetworkManager::validateSession() {
     QUrl route =
         HOST.resolved(SESSIONS).resolved(sessionId + "/").resolved(VALIDATE);
     route.setQuery({{"user_id", userId.toString(QUuid::WithoutBraces)}});
-        qDebug() << route.toString();
+    qDebug() << route.toString();
     auto request = QNetworkRequest(route);
     request.setHeader(QNetworkRequest::KnownHeaders::ContentTypeHeader,
                       "application/json");

--- a/client/network_manager.cpp
+++ b/client/network_manager.cpp
@@ -1,5 +1,6 @@
 #include "network_manager.h"
 #include <utility>
+#include "entities/gameinfo.h"
 
 NetworkManager::NetworkManager(QObject *parent) : manager(parent) {
     gamePollingTimer = new QTimer(this);
@@ -52,9 +53,17 @@ void NetworkManager::getGamesConfig(const QString &gameId) {
 }
 
 void NetworkManager::gotGamesConfig(QNetworkReply *reply) {
-    qDebug() << "Got Games Config:";
-    qDebug() << reply->readAll();
-    qDebug() << "Not implemented yet!!";
+    if (reply->error()) {
+        qDebug() << reply->errorString();
+        return;
+    }
+    QByteArray answer = reply->readAll();
+    reply->close();
+    reply->deleteLater();
+    qDebug() << answer;
+    GameInfo gameInfo;
+    gameInfo.read(QJsonDocument::fromJson(answer).object());
+    emit gotGameInfo(gameInfo);
 }
 
 void NetworkManager::getGamesClient(const QString &gameId) {

--- a/client/network_manager.cpp
+++ b/client/network_manager.cpp
@@ -225,6 +225,19 @@ void NetworkManager::startSession() {
             [reply, this]() { gotPostResponse(reply); });
 }
 
+void NetworkManager::leaveSession() {
+    QUrl route =
+        HOST.resolved(SESSIONS).resolved(sessionId + "/").resolved(LEAVE);
+    route.setQuery({{"user_id", userId.toString(QUuid::WithoutBraces)}});
+    qDebug() << route.toString();
+    auto request = QNetworkRequest(route);
+    request.setHeader(QNetworkRequest::KnownHeaders::ContentTypeHeader,
+                      "application/json");
+    auto reply = manager.post(request, "{}");
+    connect(reply, &QNetworkReply::finished, this,
+            [reply, this]() { gotPostResponse(reply); });
+}
+
 void NetworkManager::startGamePolling() {
     gamePollingTimer->start();
 }

--- a/client/network_manager.cpp
+++ b/client/network_manager.cpp
@@ -130,6 +130,9 @@ void NetworkManager::gotSession(QNetworkReply *reply) {
     SessionInfo sessionInfo;
     sessionInfo.read(QJsonDocument::fromJson(answer).object());
     sessionId = sessionInfo.session_id;
+    sessionInfo.isHost =
+        sessionInfo.host_id == userId.toString(QUuid::WithoutBraces);
+
     emit gotSessionInfo(sessionInfo);
 }
 
@@ -180,7 +183,7 @@ void NetworkManager::validateSession() {
     QUrl route =
         HOST.resolved(SESSIONS).resolved(sessionId + "/").resolved(VALIDATE);
     route.setQuery({{"user_id", userId.toString(QUuid::WithoutBraces)}});
-    //    qDebug() << route.toString();
+        qDebug() << route.toString();
     auto request = QNetworkRequest(route);
     request.setHeader(QNetworkRequest::KnownHeaders::ContentTypeHeader,
                       "application/json");

--- a/client/network_manager.h
+++ b/client/network_manager.h
@@ -40,7 +40,6 @@ public slots:
     void leaveSession();
     void changeRoleInSession(int newRole);
 
-
     void startGamePolling();
     void stopGamePolling();
     void startSessionPolling();

--- a/client/network_manager.h
+++ b/client/network_manager.h
@@ -19,7 +19,7 @@ public:
     const static inline QUrl DEFAULT_HOST{"https://develop.api.cavoke.wlko.me"};
     explicit NetworkManager(QObject *parent = nullptr);
     void changeHost(const QUrl &newHost);
-    const QString getUserId();
+    QString getUserId();
 
 public slots:
     void getHealth();
@@ -38,6 +38,8 @@ public slots:
     void getSessionInfo();
     void startSession();
     void leaveSession();
+    void changeRoleInSession(int newRole);
+
 
     void startGamePolling();
     void stopGamePolling();
@@ -99,6 +101,7 @@ private:
     //    rooms block
     const static inline QUrl START{"start"};
     const static inline QUrl LEAVE{"leave"};
+    const static inline QUrl CHANGE_ROLE{"change_role"};
 };
 
 #endif  // CAVOKE_CLIENT_NETWORK_MANAGER_H

--- a/client/network_manager.h
+++ b/client/network_manager.h
@@ -19,6 +19,7 @@ public:
     const static inline QUrl DEFAULT_HOST{"https://develop.api.cavoke.wlko.me"};
     explicit NetworkManager(QObject *parent = nullptr);
     void changeHost(const QUrl &newHost);
+    const QString getUserId();
 
 public slots:
     void getHealth();

--- a/client/network_manager.h
+++ b/client/network_manager.h
@@ -10,6 +10,7 @@
 #include <QtCore/QTimer>
 #include <QtNetwork/QNetworkAccessManager>
 #include <QtNetwork/QNetworkReply>
+#include "entities/gameinfo.h"
 #include "entities/sessioninfo.h"
 #include "entities/validationresult.h"
 struct NetworkManager : public QObject {
@@ -47,6 +48,7 @@ signals:
     void finalizedGamesList(QJsonArray list);
     void gotGameUpdate(const QString &jsonField);
     void downloadedGameFile(QFile *file, const QString &gameId);
+    void gotGameInfo(const GameInfo &gameInfo);
     void gotSessionInfo(const SessionInfo &sessionInfo);
     void gotValidationResult(const ValidationResult &validationResult);
 

--- a/client/network_manager.h
+++ b/client/network_manager.h
@@ -36,6 +36,7 @@ public slots:
     void validateSession();
     void getSessionInfo();
     void startSession();
+    void leaveSession();
 
     void startGamePolling();
     void stopGamePolling();
@@ -96,6 +97,7 @@ private:
     //    const static inline QUrl GET_INFO{"get_info"}; // already exists in
     //    rooms block
     const static inline QUrl START{"start"};
+    const static inline QUrl LEAVE{"leave"};
 };
 
 #endif  // CAVOKE_CLIENT_NETWORK_MANAGER_H

--- a/client/network_manager.h
+++ b/client/network_manager.h
@@ -35,8 +35,6 @@ public slots:
     void validateSession();
     void getSessionInfo();
     void startSession();
-    // TODO: Not implemented
-    //    void getSessionInfoByInviteCode(const QString &inviteCode);
 
     void startGamePolling();
     void stopGamePolling();
@@ -96,9 +94,6 @@ private:
     //    const static inline QUrl GET_INFO{"get_info"}; // already exists in
     //    rooms block
     const static inline QUrl START{"start"};
-    // TODO: Not implemented
-    const static inline QUrl SESSIONS_GET_INFO_BY_INVITE_CODE{
-        "sessions/get_info_by_invite_code"};
 };
 
 #endif  // CAVOKE_CLIENT_NETWORK_MANAGER_H

--- a/client/views/protoroomview.cpp
+++ b/client/views/protoroomview.cpp
@@ -83,20 +83,16 @@ void ProtoRoomView::on_backButton_clicked() {
 void ProtoRoomView::updateGameName(const QString &gameName) {
     ui->gameNameLabel->setText(gameName);
 }
-void ProtoRoomView::gotRolesListUpdate(
-    const std::vector<std::pair<QString, int>> &newRolesList) {
+void ProtoRoomView::gotRolesListUpdate(const std::vector<Role> &newRolesList) {
     // Some bad way to check whether list actually updated
     // TODO: implement it
 
-    ourRole = newRolesList.front().second;
+    ourRole = newRolesList.front().id;
     ui->roleComboBox->clear();
     for (const auto &roleIdAndName : newRolesList) {
-        ui->roleComboBox->addItem(roleIdAndName.first, roleIdAndName.second);
-        //        qDebug() << roleIdAndName.first << ' ' <<
-        //        roleIdAndName.second;
+        ui->roleComboBox->addItem(roleIdAndName.name, roleIdAndName.id);
     }
     if (ui->roleComboBox->count() > 0) {
-        //        qDebug() << "SET: " << ui->roleComboBox->count() - 1;
         ui->roleComboBox->setCurrentIndex(0);
     } else {
         ui->roleComboBox->setCurrentIndex(-1);

--- a/client/views/protoroomview.cpp
+++ b/client/views/protoroomview.cpp
@@ -14,11 +14,12 @@ ProtoRoomView::~ProtoRoomView() {
 
 void ProtoRoomView::repeaterCurrentIndexChanged(int index) {
     if (index == -1 || ui->roleComboBox->itemData(index).toInt() == ourRole) {
-//        displayEmpty();
+        //        displayEmpty();
         return;
     }
-//    qDebug() << "Chosen: " << ui->roleComboBox->itemText(index);
-    qDebug() << "Got new role index: " << ui->roleComboBox->itemData(index).toInt();
+    //    qDebug() << "Chosen: " << ui->roleComboBox->itemText(index);
+    qDebug() << "Got new role index: "
+             << ui->roleComboBox->itemData(index).toInt();
     emit newRoleChosen(ui->roleComboBox->itemData(index).toInt());
 }
 
@@ -104,10 +105,11 @@ void ProtoRoomView::gotRolesListUpdate(
     ui->roleComboBox->clear();
     for (const auto &roleIdAndName : newRolesList) {
         ui->roleComboBox->addItem(roleIdAndName.first, roleIdAndName.second);
-//        qDebug() << roleIdAndName.first << ' ' << roleIdAndName.second;
+        //        qDebug() << roleIdAndName.first << ' ' <<
+        //        roleIdAndName.second;
     }
     if (ui->roleComboBox->count() > 0) {
-//        qDebug() << "SET: " << ui->roleComboBox->count() - 1;
+        //        qDebug() << "SET: " << ui->roleComboBox->count() - 1;
         ui->roleComboBox->setCurrentIndex(0);
     } else {
         ui->roleComboBox->setCurrentIndex(-1);

--- a/client/views/protoroomview.cpp
+++ b/client/views/protoroomview.cpp
@@ -45,6 +45,11 @@ void ProtoRoomView::updateSessionInfo(const SessionInfo &sessionInfo) {
         }
         cnt++;
     }
+    if (sessionInfo.isHost) {
+        show_as_host();
+    } else {
+        show_as_guest();
+    }
     if (sessionInfo.status == 1) {
         this->close();
         emit joinedCreatedGame();
@@ -61,34 +66,16 @@ void ProtoRoomView::on_joinGameButton_clicked() {
     emit createdGame();
 }
 
-void ProtoRoomView::prepareJoinCreate(bool _isJoining) {
+void ProtoRoomView::clear() {
     ui->currentPlayersHLabel->hide();
     ui->playersListWidget->hide();
 
     ui->inviteCodeLabel->setText("Unknown");
     ui->gameNameLabel->setText("Unknown");
-
-    isJoining = _isJoining;
-    if (isJoining) {
-        //        ui->headerLabel->setText("Joining game session");
-        ui->gameNameHLabel->show();
-        ui->gameNameLabel->show();
-        ui->inviteCodeHLabel->hide();
-        ui->inviteCodeLabel->hide();
-        ui->waitForHostLabel->show();
-        ui->joinGameButton->hide();
-    } else {
-        //        ui->headerLabel->setText("Creating game session");
-        ui->gameNameHLabel->hide();
-        ui->gameNameLabel->hide();
-        ui->inviteCodeHLabel->show();
-        ui->inviteCodeLabel->show();
-        ui->waitForHostLabel->hide();
-        ui->joinGameButton->show();
-    }
 }
 
 void ProtoRoomView::on_backButton_clicked() {
+    this->clear();
     this->close();
     emit leftRoom();
     emit shownStartView();
@@ -114,4 +101,22 @@ void ProtoRoomView::gotRolesListUpdate(
     } else {
         ui->roleComboBox->setCurrentIndex(-1);
     }
+}
+void ProtoRoomView::show_as_host() {
+    ui->gameNameHLabel->hide();
+    ui->gameNameLabel->hide();
+    ui->inviteCodeHLabel->show();
+    ui->inviteCodeLabel->show();
+    ui->waitForHostLabel->hide();
+    ui->joinErrorLabel->show();
+    ui->joinGameButton->show();
+}
+void ProtoRoomView::show_as_guest() {
+    ui->gameNameHLabel->show();
+    ui->gameNameLabel->show();
+    ui->inviteCodeHLabel->hide();
+    ui->inviteCodeLabel->hide();
+    ui->waitForHostLabel->show();
+    ui->joinErrorLabel->hide();
+    ui->joinGameButton->hide();
 }

--- a/client/views/protoroomview.cpp
+++ b/client/views/protoroomview.cpp
@@ -18,7 +18,7 @@ void ProtoRoomView::updateStatus(CreatingGameStatus newStatus) {
 
 void ProtoRoomView::updateSessionInfo(const SessionInfo &sessionInfo) {
     ui->inviteCodeLabel->setText(sessionInfo.invite_code);
-//    ui->gameNameLabel->setText(sessionInfo.game_id);
+    //    ui->gameNameLabel->setText(sessionInfo.game_id);
 
     ui->playersListWidget->clear();
     int cnt = 0;
@@ -82,4 +82,19 @@ void ProtoRoomView::on_backButton_clicked() {
 }
 void ProtoRoomView::updateGameName(const QString &gameName) {
     ui->gameNameLabel->setText(gameName);
+}
+void ProtoRoomView::gotRolesListUpdate(
+    const std::vector<std::pair<QString, int>> &newRolesList) {
+    // Some bad way to check whether list actually updated
+    // TODO: implement it
+
+    ui->roleComboBox->clear();
+    for (const auto &roleIdAndName : newRolesList) {
+        ui->roleComboBox->addItem(roleIdAndName.first, roleIdAndName.second);
+    }
+    if (ui->roleComboBox->count() > 0) {
+        ui->roleComboBox->setCurrentIndex(ui->roleComboBox->count() - 1);
+    } else {
+        ui->roleComboBox->setCurrentIndex(-1);
+    }
 }

--- a/client/views/protoroomview.cpp
+++ b/client/views/protoroomview.cpp
@@ -4,10 +4,22 @@
 ProtoRoomView::ProtoRoomView(QWidget *parent)
     : QMainWindow(parent), ui(new Ui::ProtoRoomView) {
     ui->setupUi(this);
+    connect(ui->roleComboBox, SIGNAL(currentIndexChanged(int)), this,
+            SLOT(repeaterCurrentIndexChanged(int)));
 }
 
 ProtoRoomView::~ProtoRoomView() {
     delete ui;
+}
+
+void ProtoRoomView::repeaterCurrentIndexChanged(int index) {
+    if (index == -1 || ui->roleComboBox->itemData(index).toInt() == ourRole) {
+//        displayEmpty();
+        return;
+    }
+//    qDebug() << "Chosen: " << ui->roleComboBox->itemText(index);
+    qDebug() << "Got new role index: " << ui->roleComboBox->itemData(index).toInt();
+    emit newRoleChosen(ui->roleComboBox->itemData(index).toInt());
 }
 
 void ProtoRoomView::updateStatus(CreatingGameStatus newStatus) {
@@ -88,12 +100,15 @@ void ProtoRoomView::gotRolesListUpdate(
     // Some bad way to check whether list actually updated
     // TODO: implement it
 
+    ourRole = newRolesList.front().second;
     ui->roleComboBox->clear();
     for (const auto &roleIdAndName : newRolesList) {
         ui->roleComboBox->addItem(roleIdAndName.first, roleIdAndName.second);
+//        qDebug() << roleIdAndName.first << ' ' << roleIdAndName.second;
     }
     if (ui->roleComboBox->count() > 0) {
-        ui->roleComboBox->setCurrentIndex(ui->roleComboBox->count() - 1);
+//        qDebug() << "SET: " << ui->roleComboBox->count() - 1;
+        ui->roleComboBox->setCurrentIndex(0);
     } else {
         ui->roleComboBox->setCurrentIndex(-1);
     }

--- a/client/views/protoroomview.cpp
+++ b/client/views/protoroomview.cpp
@@ -77,6 +77,7 @@ void ProtoRoomView::prepareJoinCreate(bool _isJoining) {
 
 void ProtoRoomView::on_backButton_clicked() {
     this->close();
+    emit leftRoom();
     emit shownStartView();
 }
 void ProtoRoomView::updateGameName(const QString &gameName) {

--- a/client/views/protoroomview.cpp
+++ b/client/views/protoroomview.cpp
@@ -18,8 +18,7 @@ void ProtoRoomView::updateStatus(CreatingGameStatus newStatus) {
 
 void ProtoRoomView::updateSessionInfo(const SessionInfo &sessionInfo) {
     ui->inviteCodeLabel->setText(sessionInfo.invite_code);
-    ui->gameNameLabel->setText(sessionInfo.game_id);
-    gameName = sessionInfo.game_id;
+//    ui->gameNameLabel->setText(sessionInfo.game_id);
 
     ui->playersListWidget->clear();
     int cnt = 0;
@@ -79,4 +78,7 @@ void ProtoRoomView::prepareJoinCreate(bool _isJoining) {
 void ProtoRoomView::on_backButton_clicked() {
     this->close();
     emit shownStartView();
+}
+void ProtoRoomView::updateGameName(const QString &gameName) {
+    ui->gameNameLabel->setText(gameName);
 }

--- a/client/views/protoroomview.h
+++ b/client/views/protoroomview.h
@@ -22,6 +22,9 @@ public slots:
     void prepareJoinCreate(bool _isJoining);
     void updateValidationResult(const ValidationResult &validationResult);
     void updateGameName(const QString &gameName);
+    void gotRolesListUpdate(
+        const std::vector<std::pair<QString, int>>
+            &newRolesList);  // Probably should use some struct...
 
 signals:
     void createdGame();

--- a/client/views/protoroomview.h
+++ b/client/views/protoroomview.h
@@ -21,6 +21,7 @@ public slots:
     void updateSessionInfo(const SessionInfo &sessionInfo);
     void prepareJoinCreate(bool _isJoining);
     void updateValidationResult(const ValidationResult &validationResult);
+    void updateGameName(const QString &gameName);
 
 signals:
     void createdGame();
@@ -39,7 +40,6 @@ private:
         {CreatingGameStatus::REQUESTED, "Sending request"},
         {CreatingGameStatus::DONE, "Done"},
     };
-    QString gameName;
     bool isJoining = false;
 };
 

--- a/client/views/protoroomview.h
+++ b/client/views/protoroomview.h
@@ -1,6 +1,7 @@
 #ifndef CAVOKE_CLIENT_MIDDLESCREENVIEW_H
 #define CAVOKE_CLIENT_MIDDLESCREENVIEW_H
 
+#include <entities/role.h>
 #include <entities/sessioninfo.h>
 #include <entities/validationresult.h>
 #include <QMainWindow>
@@ -23,7 +24,7 @@ public slots:
     void updateValidationResult(const ValidationResult &validationResult);
     void updateGameName(const QString &gameName);
     void gotRolesListUpdate(
-        const std::vector<std::pair<QString, int>>
+        const std::vector<Role>
             &newRolesList);  // Probably should use some struct...
 
 signals:

--- a/client/views/protoroomview.h
+++ b/client/views/protoroomview.h
@@ -19,7 +19,7 @@ public:
 public slots:
     void updateStatus(CreatingGameStatus newStatus);
     void updateSessionInfo(const SessionInfo &sessionInfo);
-    void prepareJoinCreate(bool _isJoining);
+    void clear();
     void updateValidationResult(const ValidationResult &validationResult);
     void updateGameName(const QString &gameName);
     void gotRolesListUpdate(
@@ -40,13 +40,14 @@ private slots:
 
 private:
     Ui::ProtoRoomView *ui;
+    void show_as_host();
+    void show_as_guest();
     const std::map<CreatingGameStatus, QString> STATUS = {
         {CreatingGameStatus::UNKNOWN, "Unknown"},
         {CreatingGameStatus::DOWNLOAD, "Downloading"},
         {CreatingGameStatus::REQUESTED, "Sending request"},
         {CreatingGameStatus::DONE, "Done"},
     };
-    bool isJoining = false;
     int ourRole = -1;
 };
 

--- a/client/views/protoroomview.h
+++ b/client/views/protoroomview.h
@@ -27,6 +27,7 @@ signals:
     void createdGame();
     void joinedCreatedGame();
     void shownStartView();
+    void leftRoom();
 
 private slots:
     void on_joinGameButton_clicked();

--- a/client/views/protoroomview.h
+++ b/client/views/protoroomview.h
@@ -31,10 +31,12 @@ signals:
     void joinedCreatedGame();
     void shownStartView();
     void leftRoom();
+    void newRoleChosen(int roleId);
 
 private slots:
     void on_joinGameButton_clicked();
     void on_backButton_clicked();
+    void repeaterCurrentIndexChanged(int index);
 
 private:
     Ui::ProtoRoomView *ui;
@@ -45,6 +47,7 @@ private:
         {CreatingGameStatus::DONE, "Done"},
     };
     bool isJoining = false;
+    int ourRole = -1;
 };
 
 #endif  // CAVOKE_CLIENT_MIDDLESCREENVIEW_H

--- a/client/views/protoroomview.ui
+++ b/client/views/protoroomview.ui
@@ -48,7 +48,7 @@
       </rect>
      </property>
      <property name="text">
-      <string>Back</string>
+      <string>Leave</string>
      </property>
     </widget>
     <widget class="QWidget" name="gridLayoutWidget">
@@ -60,14 +60,43 @@
        <height>481</height>
       </rect>
      </property>
-     <layout class="QGridLayout" name="gridLayout" rowstretch="2,3,1,1,1,1,2,1,1,4" columnstretch="1,3">
+     <layout class="QGridLayout" name="gridLayout" rowstretch="2,3,1,1,1,1,2,1,1,1,5" columnstretch="1,3">
       <property name="leftMargin">
        <number>10</number>
       </property>
       <property name="rightMargin">
        <number>10</number>
       </property>
-      <item row="8" column="0" colspan="2">
+      <item row="4" column="0">
+       <widget class="QLabel" name="inviteCodeHLabel">
+        <property name="text">
+         <string>Invite code:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="currentPlayersHLabel">
+        <property name="text">
+         <string>Current players:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1" rowspan="2">
+       <widget class="QListWidget" name="playersListWidget"/>
+      </item>
+      <item row="3" column="1">
+       <widget class="QLabel" name="gameNameLabel">
+        <property name="font">
+         <font>
+          <pointsize>14</pointsize>
+         </font>
+        </property>
+        <property name="text">
+         <string>Unknown</string>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="0" colspan="2">
        <widget class="QLabel" name="waitForHostLabel">
         <property name="text">
          <string>Wait for the host to launch the game</string>
@@ -77,7 +106,61 @@
         </property>
        </widget>
       </item>
-      <item row="9" column="0" colspan="2">
+      <item row="3" column="0">
+       <widget class="QLabel" name="gameNameHLabel">
+        <property name="text">
+         <string>Game name:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLabel" name="statusLabel">
+        <property name="font">
+         <font>
+          <pointsize>14</pointsize>
+         </font>
+        </property>
+        <property name="text">
+         <string>Unknown</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QLabel" name="inviteCodeLabel">
+        <property name="font">
+         <font>
+          <pointsize>14</pointsize>
+         </font>
+        </property>
+        <property name="mouseTracking">
+         <bool>false</bool>
+        </property>
+        <property name="acceptDrops">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Unknown</string>
+        </property>
+        <property name="textInteractionFlags">
+         <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QLabel" name="joinErrorLabel">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Current status:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="0" colspan="2">
        <layout class="QHBoxLayout" name="horizontalLayout">
         <property name="leftMargin">
          <number>200</number>
@@ -112,56 +195,6 @@
         </item>
        </layout>
       </item>
-      <item row="4" column="1">
-       <widget class="QLabel" name="inviteCodeLabel">
-        <property name="font">
-         <font>
-          <pointsize>14</pointsize>
-         </font>
-        </property>
-        <property name="mouseTracking">
-         <bool>false</bool>
-        </property>
-        <property name="acceptDrops">
-         <bool>false</bool>
-        </property>
-        <property name="text">
-         <string>Unknown</string>
-        </property>
-        <property name="textInteractionFlags">
-         <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="inviteCodeHLabel">
-        <property name="text">
-         <string>Invite code:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QLabel" name="statusLabel">
-        <property name="font">
-         <font>
-          <pointsize>14</pointsize>
-         </font>
-        </property>
-        <property name="text">
-         <string>Unknown</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="1" rowspan="2">
-       <widget class="QListWidget" name="playersListWidget"/>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Current status:</string>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="0" rowspan="2" colspan="2">
        <widget class="QLabel" name="headerLabel">
         <property name="font">
@@ -177,38 +210,15 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="gameNameHLabel">
+      <item row="8" column="0">
+       <widget class="QLabel" name="playerRoleLabel">
         <property name="text">
-         <string>Game name:</string>
+         <string>Your role:</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
-       <widget class="QLabel" name="gameNameLabel">
-        <property name="font">
-         <font>
-          <pointsize>14</pointsize>
-         </font>
-        </property>
-        <property name="text">
-         <string>Unknown</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="1">
-       <widget class="QLabel" name="joinErrorLabel">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0">
-       <widget class="QLabel" name="currentPlayersHLabel">
-        <property name="text">
-         <string>Current players:</string>
-        </property>
-       </widget>
+      <item row="8" column="1">
+       <widget class="QComboBox" name="roleComboBox"/>
       </item>
      </layout>
     </widget>
@@ -220,7 +230,7 @@
      <x>0</x>
      <y>0</y>
      <width>800</width>
-     <height>19</height>
+     <height>28</height>
     </rect>
    </property>
   </widget>


### PR DESCRIPTION
На клиент добавлена возможность менять свою роль -- менять, кем играешь в этой сессии (крестиками/ноликами)

На ProtoRoomView (Waiting Room) добавлено выпадающее меню, в котором отображается текущая роль игрока и свободные для выбора роли.

Клиент теперь загружает информацию об игре, и за счёт неё ставит настоящее название игры и вычисляет список свободных ролей (позиций)

На данный момент ещё не полностью протестировано