### PR TITLE
feature/client-stats-representation

### DIFF
--- a/client/controllers/cavokeclientcontroller.cpp
+++ b/client/controllers/cavokeclientcontroller.cpp
@@ -128,6 +128,17 @@ CavokeClientController::CavokeClientController(QObject *parent)
     connect(&networkManager, SIGNAL(gotDisplayName(QString)), &settingsView,
             SLOT(updateDisplayName(QString)));
 
+    // statisticsView actions
+    connect(&networkManager, SIGNAL(gotUserStatistics(UserStatistics)),
+            &statisticsView, SLOT(gotUserStatisticsUpdate(UserStatistics)));
+    connect(&statisticsView, SIGNAL(requestedRefresh()), &networkManager,
+            SLOT(getMyUserStatistics()));
+    connect(&networkManager, SIGNAL(gotUserGameStatistics(UserGameStatistics)),
+            &statisticsView,
+            SLOT(gotUserGameStatisticsUpdate(UserGameStatistics)));
+    connect(&statisticsView, SIGNAL(statisticsGameChanged(QString)),
+            &networkManager, SLOT(getMyUserGameStatistics(QString)));
+
     defaultSettingsInitialization();
 
     // oauth reply handler
@@ -177,6 +188,9 @@ void CavokeClientController::leftSession() {
 
 void CavokeClientController::showStartView() {
     startView.show();
+    if (cavoke::auth::AuthenticationManager::getInstance().checkAuthStatus()) {
+        networkManager.getMyUserStatistics();
+    }
 }
 
 void CavokeClientController::showJoinGameView() {

--- a/client/controllers/cavokeclientcontroller.cpp
+++ b/client/controllers/cavokeclientcontroller.cpp
@@ -81,8 +81,12 @@ CavokeClientController::CavokeClientController(QObject *parent)
     // gamesListView actions
     connect(&gamesListView, SIGNAL(currentIndexChanged(int)), &model,
             SLOT(receivedGameIndexChangeInList(int)));
+    connect(&gamesListView, SIGNAL(requestGameStatistics(QString)),
+            &networkManager, SLOT(getGameStatistics(QString)));
     connect(&model, SIGNAL(updateSelectedGameInList(GameInfo)), &gamesListView,
             SLOT(gotNewSelectedGame(GameInfo)));
+    connect(&networkManager, SIGNAL(gotGameStatistics(GameStatistics)),
+            &gamesListView, SLOT(gotNewGameStatistics(GameStatistics)));
     connect(&gamesListView, SIGNAL(requestedDownloadGame(int)), &model,
             SLOT(gotIndexToDownload(int)));
     connect(this, SIGNAL(clearScreens()), &gamesListView, SLOT(displayEmpty()));
@@ -148,7 +152,8 @@ CavokeClientController::CavokeClientController(QObject *parent)
 
     // on new authentication update my user id and display name
     connect(&auth, SIGNAL(authenticated()), &networkManager, SLOT(getMe()));
-    connect(&auth, SIGNAL(authenticated()), &networkManager, SLOT(getMyUserStatistics()));
+    connect(&auth, SIGNAL(authenticated()), &networkManager,
+            SLOT(getMyUserStatistics()));
     // initialize auth in a separate thread
     QTimer::singleShot(0, [&]() { auth.init(); });
 

--- a/client/controllers/cavokeclientcontroller.cpp
+++ b/client/controllers/cavokeclientcontroller.cpp
@@ -96,6 +96,8 @@ CavokeClientController::CavokeClientController(QObject *parent)
             &createGameView, SLOT(gotGamesListUpdate(std::vector<GameInfo>)));
     connect(&model, SIGNAL(gamesListUpdated(std::vector<GameInfo>)),
             &gamesListView, SLOT(gotGamesListUpdate(std::vector<GameInfo>)));
+    connect(&model, SIGNAL(gamesListUpdated(std::vector<GameInfo>)),
+            &statisticsView, SLOT(gotGamesListUpdate(std::vector<GameInfo>)));
 
     // Download and unpack game workflow
     connect(&model, SIGNAL(downloadGame(QString)), &networkManager,

--- a/client/controllers/cavokeclientcontroller.cpp
+++ b/client/controllers/cavokeclientcontroller.cpp
@@ -148,10 +148,11 @@ CavokeClientController::CavokeClientController(QObject *parent)
 
     // on new authentication update my user id and display name
     connect(&auth, SIGNAL(authenticated()), &networkManager, SLOT(getMe()));
+    connect(&auth, SIGNAL(authenticated()), &networkManager, SLOT(getMyUserStatistics()));
     // initialize auth in a separate thread
     QTimer::singleShot(0, [&]() { auth.init(); });
 
-    startView.show();
+    showStartView();
 }
 
 void CavokeClientController::defaultSettingsInitialization() {
@@ -188,9 +189,6 @@ void CavokeClientController::leftSession() {
 
 void CavokeClientController::showStartView() {
     startView.show();
-    if (cavoke::auth::AuthenticationManager::getInstance().checkAuthStatus()) {
-        networkManager.getMyUserStatistics();
-    }
 }
 
 void CavokeClientController::showJoinGameView() {
@@ -206,6 +204,7 @@ void CavokeClientController::showCreateGameView() {
 }
 
 void CavokeClientController::showStatisticsView() {
+    statisticsView.requestUpdates();
     statisticsView.show();
 }
 

--- a/client/controllers/cavokeclientcontroller.cpp
+++ b/client/controllers/cavokeclientcontroller.cpp
@@ -8,6 +8,7 @@ CavokeClientController::CavokeClientController(QObject *parent)
       testWindowView{},
       startView{},
       joinGameView{},
+      statisticsView{},
       settingsView{},
       protoRoomView{},
       settings{} {
@@ -28,6 +29,8 @@ CavokeClientController::CavokeClientController(QObject *parent)
             SLOT(showStartView()));
     connect(&protoRoomView, SIGNAL(shownStartView()), this,
             SLOT(showStartView()));
+    connect(&statisticsView, SIGNAL(shownStartView()), this,
+            SLOT(showStartView()));
 
     // Main navigation buttons from startView
     connect(&startView, SIGNAL(shownTestWindowView()), this,
@@ -40,6 +43,8 @@ CavokeClientController::CavokeClientController(QObject *parent)
             SLOT(showGamesListView()));
     connect(&startView, SIGNAL(shownSettingsView()), this,
             SLOT(showSettingsView()));
+    connect(&startView, SIGNAL(shownStatisticsView()), this,
+            SLOT(showStatisticsView()));
 
     // startView Exit button
     connect(&startView, SIGNAL(clickedExitButton()), this,
@@ -182,6 +187,10 @@ void CavokeClientController::showGamesListView() {
 
 void CavokeClientController::showCreateGameView() {
     createGameView.show();
+}
+
+void CavokeClientController::showStatisticsView() {
+    statisticsView.show();
 }
 
 void CavokeClientController::showSettingsView() {

--- a/client/controllers/cavokeclientcontroller.h
+++ b/client/controllers/cavokeclientcontroller.h
@@ -12,6 +12,7 @@
 #include "protoroomview.h"
 #include "settingsview.h"
 #include "startview.h"
+#include "statisticsview.h"
 #include "testwindowview.h"
 
 class CavokeClientController : public QObject {
@@ -34,6 +35,7 @@ public slots:
     void showJoinGameView();
     void showGamesListView();
     void showCreateGameView();
+    void showStatisticsView();
     void showSettingsView();
     void updateSettings(const QString &displayName, const QString &host);
 
@@ -72,6 +74,7 @@ private:
     JoinGameView joinGameView;
     CreateGameView createGameView;
     GamesListView gamesListView;
+    StatisticsView statisticsView;
     SettingsView settingsView;
     ProtoRoomView protoRoomView;
     CavokeQmlGameModel *currentQmlGameModel = nullptr;

--- a/client/entities/gamestatistics.cpp
+++ b/client/entities/gamestatistics.cpp
@@ -1,0 +1,36 @@
+#include "gamestatistics.h"
+
+GameStatistics::GameStatistics() = default;
+
+GameStatistics::GameStatistics(int _average_duration_sec,
+                               int _average_players_count,
+                               int _total_time_played_sec,
+                               int _total_games_played)
+    : average_duration_sec(_average_duration_sec),
+      average_players_count(_average_players_count),
+      total_time_played_sec(_total_time_played_sec),
+      total_games_played(_total_games_played) {
+}
+
+void GameStatistics::read(const QJsonObject &json) {
+    if (json.contains(AVERAGE_DURATION_SEC) &&
+        json[AVERAGE_DURATION_SEC].isDouble()) {
+        average_duration_sec = json[AVERAGE_DURATION_SEC].toInt();
+    }
+    if (json.contains(AVERAGE_PLAYERS_COUNT) &&
+        json[AVERAGE_PLAYERS_COUNT].isDouble()) {
+        average_players_count = json[AVERAGE_PLAYERS_COUNT].toInt();
+    }
+    if (json.contains(TOTAL_TIME_PLAYED_SEC) &&
+        json[TOTAL_TIME_PLAYED_SEC].isDouble()) {
+        total_time_played_sec = json[TOTAL_TIME_PLAYED_SEC].toInt();
+    }
+    if (json.contains(TOTAL_GAMES_PLAYED) &&
+        json[TOTAL_GAMES_PLAYED].isDouble()) {
+        total_games_played = json[TOTAL_GAMES_PLAYED].toInt();
+    }
+}
+
+void GameStatistics::write(QJsonObject &json) {
+    assert(false);  // Should not be used
+}

--- a/client/entities/gamestatistics.h
+++ b/client/entities/gamestatistics.h
@@ -1,0 +1,29 @@
+#ifndef CAVOKE_GAMESTATISTICS_H
+#define CAVOKE_GAMESTATISTICS_H
+
+#include <QtCore/QJsonObject>
+#include <QtCore/QString>
+struct GameStatistics {
+public:
+    GameStatistics();
+    GameStatistics(int _average_duration_sec,
+                   int _average_players_count,
+                   int _total_time_played_sec,
+                   int _total_games_played);
+
+    void read(const QJsonObject &json);
+    static void write(QJsonObject &json);
+
+    int average_duration_sec = 0;
+    int average_players_count = 0;
+    int total_time_played_sec = 0;
+    int total_games_played = 0;
+
+private:
+    static inline const QString AVERAGE_DURATION_SEC = "average_duration_sec";
+    static inline const QString AVERAGE_PLAYERS_COUNT = "average_players_count";
+    static inline const QString TOTAL_TIME_PLAYED_SEC = "total_time_played_sec";
+    static inline const QString TOTAL_GAMES_PLAYED = "total_games_played";
+};
+
+#endif  // CAVOKE_USERSTATISTICS_H

--- a/client/entities/usergamestatistics.cpp
+++ b/client/entities/usergamestatistics.cpp
@@ -1,0 +1,33 @@
+#include "usergamestatistics.h"
+#include <utility>
+
+UserGameStatistics::UserGameStatistics() = default;
+
+UserGameStatistics::UserGameStatistics(QString _game_id,
+                                       int _time_played_sec,
+                                       int _games_played,
+                                       double _win_rate)
+    : game_id(std::move(_game_id)),
+      time_played_sec(_time_played_sec),
+      games_played(_games_played),
+      win_rate(_win_rate) {
+}
+
+void UserGameStatistics::read(const QJsonObject &json) {
+    if (json.contains(GAME_ID) && json[GAME_ID].isString()) {
+        game_id = json[GAME_ID].toString();
+    }
+    if (json.contains(TIME_PLAYED_SEC) && json[TIME_PLAYED_SEC].isDouble()) {
+        time_played_sec = json[TIME_PLAYED_SEC].toInt();
+    }
+    if (json.contains(GAMES_PLAYED) && json[GAMES_PLAYED].isDouble()) {
+        games_played = json[GAMES_PLAYED].toInt();
+    }
+    if (json.contains(WIN_RATE) && json[WIN_RATE].isDouble()) {
+        win_rate = json[WIN_RATE].toDouble();
+    }
+}
+
+void UserGameStatistics::write(QJsonObject &json) {
+    assert(false);  // Should not be used
+}

--- a/client/entities/usergamestatistics.h
+++ b/client/entities/usergamestatistics.h
@@ -6,7 +6,10 @@
 struct UserGameStatistics {
 public:
     UserGameStatistics();
-    UserGameStatistics(QString _game_id, int _time_played_sec, int _games_played, double _win_rate);
+    UserGameStatistics(QString _game_id,
+                       int _time_played_sec,
+                       int _games_played,
+                       double _win_rate);
 
     void read(const QJsonObject &json);
     static void write(QJsonObject &json);

--- a/client/entities/usergamestatistics.h
+++ b/client/entities/usergamestatistics.h
@@ -1,0 +1,26 @@
+#ifndef CAVOKE_USERGAMESTATISTICS_H
+#define CAVOKE_USERGAMESTATISTICS_H
+
+#include <QJsonObject>
+#include <QString>
+struct UserGameStatistics {
+public:
+    UserGameStatistics();
+    UserGameStatistics(QString _game_id, int _time_played_sec, int _games_played, double _win_rate);
+
+    void read(const QJsonObject &json);
+    static void write(QJsonObject &json);
+
+    QString game_id;
+    int time_played_sec = 0;
+    int games_played = 0;
+    double win_rate = 0;
+
+private:
+    static inline const QString GAME_ID = "game_id";
+    static inline const QString TIME_PLAYED_SEC = "time_played_sec";
+    static inline const QString GAMES_PLAYED = "games_played";
+    static inline const QString WIN_RATE = "win_rate";
+};
+
+#endif  // CAVOKE_USERGAMESTATISTICS_H

--- a/client/entities/userstatistics.cpp
+++ b/client/entities/userstatistics.cpp
@@ -1,0 +1,22 @@
+#include "userstatistics.h"
+
+UserStatistics::UserStatistics() = default;
+
+UserStatistics::UserStatistics(int _total_time_played_sec,
+                               int _total_games_played)
+    : total_time_played_sec(_total_time_played_sec),
+      total_games_played(_total_games_played) {
+}
+
+void UserStatistics::read(const QJsonObject &json) {
+    if (json.contains(TOTAL_TIME_PLAYED_SEC) && json[TOTAL_TIME_PLAYED_SEC].isDouble()) {
+        total_time_played_sec = json[TOTAL_TIME_PLAYED_SEC].toInt();
+    }
+    if (json.contains(TOTAL_GAMES_PLAYED) && json[TOTAL_GAMES_PLAYED].isDouble()) {
+        total_games_played = json[TOTAL_GAMES_PLAYED].toInt();
+    }
+}
+
+void UserStatistics::write(QJsonObject &json) {
+    assert(false);  // Should not be used
+}

--- a/client/entities/userstatistics.cpp
+++ b/client/entities/userstatistics.cpp
@@ -9,10 +9,12 @@ UserStatistics::UserStatistics(int _total_time_played_sec,
 }
 
 void UserStatistics::read(const QJsonObject &json) {
-    if (json.contains(TOTAL_TIME_PLAYED_SEC) && json[TOTAL_TIME_PLAYED_SEC].isDouble()) {
+    if (json.contains(TOTAL_TIME_PLAYED_SEC) &&
+        json[TOTAL_TIME_PLAYED_SEC].isDouble()) {
         total_time_played_sec = json[TOTAL_TIME_PLAYED_SEC].toInt();
     }
-    if (json.contains(TOTAL_GAMES_PLAYED) && json[TOTAL_GAMES_PLAYED].isDouble()) {
+    if (json.contains(TOTAL_GAMES_PLAYED) &&
+        json[TOTAL_GAMES_PLAYED].isDouble()) {
         total_games_played = json[TOTAL_GAMES_PLAYED].toInt();
     }
 }

--- a/client/entities/userstatistics.h
+++ b/client/entities/userstatistics.h
@@ -1,0 +1,22 @@
+#ifndef CAVOKE_USERSTATISTICS_H
+#define CAVOKE_USERSTATISTICS_H
+
+#include <QtCore/QJsonObject>
+#include <QtCore/QString>
+struct UserStatistics {
+public:
+    UserStatistics();
+    UserStatistics(int _total_time_played_sec, int _total_games_played);
+
+    void read(const QJsonObject &json);
+    static void write(QJsonObject &json);
+
+    int total_time_played_sec = 0;
+    int total_games_played = 0;
+
+private:
+    static inline const QString TOTAL_TIME_PLAYED_SEC = "total_time_played_sec";
+    static inline const QString TOTAL_GAMES_PLAYED = "total_games_played";
+};
+
+#endif  // CAVOKE_USERSTATISTICS_H

--- a/client/network_manager.cpp
+++ b/client/network_manager.cpp
@@ -308,6 +308,27 @@ void NetworkManager::gotUserGameStatistics(QNetworkReply *reply) {
     emit gotUserGameStatistics(userGameStatistics);
 }
 
+void NetworkManager::getGameStatistics(const QString &gameId) {
+    QUrl route = HOST.resolved(STATISTICS_GAME)
+                     .resolved(gameId);
+    route.setQuery({{"user_id", getUserId()}});
+    qDebug() << route.toString();
+    auto reply = oauth2->get(route);
+    connect(reply, &QNetworkReply::finished, this,
+            [reply, this]() { gotGameStatistics(reply); });
+}
+
+void NetworkManager::gotGameStatistics(QNetworkReply *reply) {
+    QByteArray answer = reply->readAll();
+    reply->close();
+    reply->deleteLater();
+    qDebug() << "Got game statistics: " << answer;
+
+    GameStatistics gameStatistics;
+    gameStatistics.read(QJsonDocument::fromJson(answer).object());
+    emit gotGameStatistics(gameStatistics);
+}
+
 void NetworkManager::startGamePolling() {
     gamePollingTimer->start();
 }

--- a/client/network_manager.cpp
+++ b/client/network_manager.cpp
@@ -309,8 +309,7 @@ void NetworkManager::gotUserGameStatistics(QNetworkReply *reply) {
 }
 
 void NetworkManager::getGameStatistics(const QString &gameId) {
-    QUrl route = HOST.resolved(STATISTICS_GAME)
-                     .resolved(gameId);
+    QUrl route = HOST.resolved(STATISTICS_GAME).resolved(gameId);
     route.setQuery({{"user_id", getUserId()}});
     qDebug() << route.toString();
     auto reply = oauth2->get(route);

--- a/client/network_manager.cpp
+++ b/client/network_manager.cpp
@@ -266,6 +266,48 @@ void NetworkManager::changeName(const QString &new_name) {
             [reply, this]() { gotPostResponse(reply); });
 }
 
+void NetworkManager::getMyUserStatistics() {
+    QUrl route = HOST.resolved(PROFILE).resolved(MY_USER_STATISTICS);
+    route.setQuery({{"user_id", getUserId()}});
+    qDebug() << route.toString();
+    auto reply = oauth2->get(route);
+    connect(reply, &QNetworkReply::finished, this,
+            [reply, this]() { gotUserStatistics(reply); });
+}
+
+void NetworkManager::gotUserStatistics(QNetworkReply *reply) {
+    QByteArray answer = reply->readAll();
+    reply->close();
+    reply->deleteLater();
+    qDebug() << "Got my user statistics: " << answer;
+
+    UserStatistics userStatistics;
+    userStatistics.read(QJsonDocument::fromJson(answer).object());
+    emit gotUserStatistics(userStatistics);
+}
+
+void NetworkManager::getMyUserGameStatistics(const QString &gameId) {
+    QUrl route = HOST.resolved(PROFILE)
+                     .resolved(MY_USER_GAME_STATISTICS)
+                     .resolved(gameId);
+    route.setQuery({{"user_id", getUserId()}});
+    qDebug() << route.toString();
+    auto reply = oauth2->get(route);
+    connect(reply, &QNetworkReply::finished, this,
+            [reply, this]() { gotUserGameStatistics(reply); });
+}
+
+void NetworkManager::gotUserGameStatistics(QNetworkReply *reply) {
+    QByteArray answer = reply->readAll();
+    reply->close();
+    reply->deleteLater();
+    qDebug() << "Got my user game statistics: " << answer;
+
+    UserGameStatistics userGameStatistics;
+    userGameStatistics.read(QJsonDocument::fromJson(answer).object());
+    emit gotUserGameStatistics(userGameStatistics);
+}
+
 void NetworkManager::startGamePolling() {
     gamePollingTimer->start();
 }

--- a/client/network_manager.h
+++ b/client/network_manager.h
@@ -13,6 +13,7 @@
 #include <QtNetwork/QNetworkReply>
 #include "AuthenticationManager.h"
 #include "entities/gameinfo.h"
+#include "entities/gamestatistics.h"
 #include "entities/sessioninfo.h"
 #include "entities/usergamestatistics.h"
 #include "entities/userstatistics.h"
@@ -48,6 +49,7 @@ public slots:
     void changeName(const QString &new_name);
     void getMyUserStatistics();
     void getMyUserGameStatistics(const QString &gameId);
+    void getGameStatistics(const QString &gameId);
 
     void startGamePolling();
     void stopGamePolling();
@@ -66,6 +68,7 @@ signals:
     void gotDisplayName(const QString &displayName);
     void gotUserStatistics(const UserStatistics &userStatistics);
     void gotUserGameStatistics(const UserGameStatistics &userGameStatistics);
+    void gotGameStatistics(const GameStatistics &gameStatistics);
 
 private slots:
     void gotHealth(QNetworkReply *reply);
@@ -79,6 +82,7 @@ private slots:
     void gotMyself(QNetworkReply *reply);
     void gotUserStatistics(QNetworkReply *reply);
     void gotUserGameStatistics(QNetworkReply *reply);
+    void gotGameStatistics(QNetworkReply *reply);
 
 private:
     QOAuth2AuthorizationCodeFlow *oauth2;
@@ -127,6 +131,8 @@ private:
     const static inline QUrl CHANGE_NAME{"change_name"};
     const static inline QUrl MY_USER_STATISTICS{"my_user_statistics"};
     const static inline QUrl MY_USER_GAME_STATISTICS{"my_user_game_statistics/"};
+
+    const static inline QUrl STATISTICS_GAME{"statistics/game/"};
 };
 
 #endif  // CAVOKE_CLIENT_NETWORK_MANAGER_H

--- a/client/network_manager.h
+++ b/client/network_manager.h
@@ -14,6 +14,8 @@
 #include "AuthenticationManager.h"
 #include "entities/gameinfo.h"
 #include "entities/sessioninfo.h"
+#include "entities/usergamestatistics.h"
+#include "entities/userstatistics.h"
 #include "entities/validationresult.h"
 
 struct NetworkManager : public QObject {
@@ -44,6 +46,8 @@ public slots:
     void changeRoleInSession(int newRole);
     void getMe();
     void changeName(const QString &new_name);
+    void getMyUserStatistics();
+    void getMyUserGameStatistics(const QString &gameId);
 
     void startGamePolling();
     void stopGamePolling();
@@ -60,6 +64,8 @@ signals:
     void gotSessionInfo(const SessionInfo &sessionInfo);
     void gotValidationResult(const ValidationResult &validationResult);
     void gotDisplayName(const QString &displayName);
+    void gotUserStatistics(const UserStatistics &userStatistics);
+    void gotUserGameStatistics(const UserGameStatistics &userGameStatistics);
 
 private slots:
     void gotHealth(QNetworkReply *reply);
@@ -71,6 +77,8 @@ private slots:
     void gotPlayState(QNetworkReply *reply);
     void gotGamesClient(QNetworkReply *reply, const QString &gameId);
     void gotMyself(QNetworkReply *reply);
+    void gotUserStatistics(QNetworkReply *reply);
+    void gotUserGameStatistics(QNetworkReply *reply);
 
 private:
     QOAuth2AuthorizationCodeFlow *oauth2;
@@ -117,6 +125,8 @@ private:
     const static inline QUrl PROFILE{"profile/"};
     const static inline QUrl GET_ME{"get_me"};
     const static inline QUrl CHANGE_NAME{"change_name"};
+    const static inline QUrl MY_USER_STATISTICS{"my_user_statistics"};
+    const static inline QUrl MY_USER_GAME_STATISTICS{"my_user_game_statistics/"};
 };
 
 #endif  // CAVOKE_CLIENT_NETWORK_MANAGER_H

--- a/client/network_manager.h
+++ b/client/network_manager.h
@@ -130,7 +130,8 @@ private:
     const static inline QUrl GET_ME{"get_me"};
     const static inline QUrl CHANGE_NAME{"change_name"};
     const static inline QUrl MY_USER_STATISTICS{"my_user_statistics"};
-    const static inline QUrl MY_USER_GAME_STATISTICS{"my_user_game_statistics/"};
+    const static inline QUrl MY_USER_GAME_STATISTICS{
+        "my_user_game_statistics/"};
 
     const static inline QUrl STATISTICS_GAME{"statistics/game/"};
 };

--- a/client/views/gameslistview.cpp
+++ b/client/views/gameslistview.cpp
@@ -4,7 +4,7 @@
 GamesListView::GamesListView(QWidget *parent)
     : QMainWindow(parent), ui(new Ui::GamesListView) {
     ui->setupUi(this);
-    connect(ui->gamesListWidget, SIGNAL(currentRowChanged(int)), this,
+    connect(ui->gameNameComboBox, SIGNAL(currentIndexChanged(int)), this,
             SLOT(repeaterCurrentIndexChanged(int)));
 }
 
@@ -14,6 +14,7 @@ void GamesListView::repeaterCurrentIndexChanged(int index) {
         return;
     }
     emit currentIndexChanged(index);
+    emit requestGameStatistics(ui->gameNameComboBox->currentData().toString());
 }
 
 GamesListView::~GamesListView() {
@@ -26,27 +27,36 @@ void GamesListView::on_backButton_clicked() {
 }
 
 void GamesListView::on_downloadQmlButton_clicked() {
-    emit requestedDownloadGame(ui->gamesListWidget->currentRow());
+    emit requestedDownloadGame(ui->gameNameComboBox->currentIndex());
 }
 
 void GamesListView::gotGamesListUpdate(
     const std::vector<GameInfo> &newGamesList) {
-    ui->gamesListWidget->clear();
+    ui->gameNameComboBox->clear();
     for (const auto &gameInfo : newGamesList) {
-        ui->gamesListWidget->addItem(gameInfo.display_name);
+        ui->gameNameComboBox->addItem(gameInfo.display_name, gameInfo.id);
     }
     //    ui->gamesListWidget->setCurrentIndex(-1); // Is needed? Tests required
 }
 
 void GamesListView::gotNewSelectedGame(const GameInfo &gameInfo) {
-    ui->gameNameLabel->setText(gameInfo.display_name);
     ui->gameDescriptionTextBrowser->setText(gameInfo.description);
-    ui->playersAmountLabel->setText(QString::number(gameInfo.players_num));
+    ui->playersAllowedLabel->setText(QString::number(gameInfo.players_num));
     //    ui->createGameButton->setEnabled(true);
 }
 
+void GamesListView::gotNewGameStatistics(const GameStatistics &gameStatistics) {
+    ui->averageDurationLabel->setText(
+        QString::number(gameStatistics.average_duration_sec));
+    ui->averagePlayersLabel->setText(
+        QString::number(gameStatistics.average_players_count));
+    ui->totalTimePlayedLabel->setText(
+        QString::number(gameStatistics.total_time_played_sec));
+    ui->totalGamesPlayedLabel->setText(
+        QString::number(gameStatistics.total_games_played));
+}
+
 void GamesListView::displayEmpty() {
-    ui->gameNameLabel->clear();
     ui->gameDescriptionTextBrowser->clear();
-    ui->playersAmountLabel->clear();
+    ui->playersAllowedLabel->clear();
 }

--- a/client/views/gameslistview.h
+++ b/client/views/gameslistview.h
@@ -3,6 +3,7 @@
 
 #include <entities/gameinfo.h>
 #include <QMainWindow>
+#include "entities/gamestatistics.h"
 
 namespace Ui {
 class GamesListView;
@@ -18,10 +19,12 @@ public slots:
     void gotGamesListUpdate(const std::vector<GameInfo> &newGamesList);
     void gotNewSelectedGame(const GameInfo &gameInfo);
     void displayEmpty();
+    void gotNewGameStatistics(const GameStatistics &gameStatistics);
 
 signals:
     void shownStartView();
     void currentIndexChanged(int index);
+    void requestGameStatistics(const QString &gameId);
     void requestedDownloadGame(int index);
 
 private slots:

--- a/client/views/gameslistview.ui
+++ b/client/views/gameslistview.ui
@@ -26,116 +26,207 @@
    <string>Cavoke</string>
   </property>
   <widget class="QWidget" name="centralwidget">
-   <widget class="QPushButton" name="backButton">
+   <widget class="QGroupBox" name="groupBox">
     <property name="geometry">
      <rect>
-      <x>40</x>
-      <y>480</y>
-      <width>90</width>
-      <height>32</height>
+      <x>9</x>
+      <y>9</y>
+      <width>782</width>
+      <height>541</height>
      </rect>
     </property>
-    <property name="text">
-     <string>Back</string>
+    <property name="title">
+     <string/>
     </property>
-   </widget>
-   <widget class="QLabel" name="label">
-    <property name="geometry">
-     <rect>
-      <x>250</x>
-      <y>60</y>
-      <width>241</width>
-      <height>41</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>ALL AVAILABLE GAMES ON SERVER</string>
-    </property>
-    <property name="scaledContents">
-     <bool>false</bool>
-    </property>
-    <property name="alignment">
-     <set>Qt::AlignCenter</set>
-    </property>
-   </widget>
-   <widget class="QListWidget" name="gamesListWidget">
-    <property name="geometry">
-     <rect>
-      <x>145</x>
-      <y>121</y>
-      <width>371</width>
-      <height>321</height>
-     </rect>
-    </property>
-   </widget>
-   <widget class="QTextBrowser" name="gameDescriptionTextBrowser">
-    <property name="geometry">
-     <rect>
-      <x>540</x>
-      <y>210</y>
-      <width>251</width>
-      <height>121</height>
-     </rect>
-    </property>
-    <property name="html">
-     <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+    <widget class="QPushButton" name="backButton">
+     <property name="geometry">
+      <rect>
+       <x>1</x>
+       <y>4</y>
+       <width>61</width>
+       <height>31</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Back</string>
+     </property>
+    </widget>
+    <widget class="QWidget" name="gridLayoutWidget">
+     <property name="geometry">
+      <rect>
+       <x>59</x>
+       <y>29</y>
+       <width>661</width>
+       <height>481</height>
+      </rect>
+     </property>
+     <layout class="QGridLayout" name="gridLayout" rowstretch="4,1,1,4,1,1,1,1,4" columnstretch="1,2">
+      <property name="leftMargin">
+       <number>10</number>
+      </property>
+      <property name="rightMargin">
+       <number>10</number>
+      </property>
+      <item row="1" column="1">
+       <widget class="QComboBox" name="gameNameComboBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Ignored" vsizetype="Ignored">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="0" colspan="2">
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <property name="leftMargin">
+         <number>200</number>
+        </property>
+        <property name="topMargin">
+         <number>20</number>
+        </property>
+        <property name="rightMargin">
+         <number>200</number>
+        </property>
+        <property name="bottomMargin">
+         <number>20</number>
+        </property>
+        <item>
+         <widget class="QPushButton" name="downloadQmlButton">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Ignored" vsizetype="Ignored">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Download QML</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Players allowed:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Game name:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QTextBrowser" name="gameDescriptionTextBrowser">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Ignored" vsizetype="Ignored">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="html">
+         <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Cantarell'; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Game description&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-    </property>
-   </widget>
-   <widget class="QLabel" name="gameNameLabel">
-    <property name="geometry">
-     <rect>
-      <x>550</x>
-      <y>130</y>
-      <width>221</width>
-      <height>21</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Game name</string>
-    </property>
-   </widget>
-   <widget class="QLabel" name="label_3">
-    <property name="geometry">
-     <rect>
-      <x>550</x>
-      <y>170</y>
-      <width>111</width>
-      <height>21</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Players allowed:</string>
-    </property>
-   </widget>
-   <widget class="QLabel" name="playersAmountLabel">
-    <property name="geometry">
-     <rect>
-      <x>670</x>
-      <y>170</y>
-      <width>57</width>
-      <height>16</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>0</string>
-    </property>
-   </widget>
-   <widget class="QPushButton" name="downloadQmlButton">
-    <property name="geometry">
-     <rect>
-      <x>550</x>
-      <y>370</y>
-      <width>121</width>
-      <height>31</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Download QML</string>
-    </property>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLabel" name="playersAllowedLabel">
+        <property name="text">
+         <string>0</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_6">
+        <property name="text">
+         <string>Average duration, seconds:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>Game description:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_7">
+        <property name="text">
+         <string>Average players count:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" colspan="2">
+       <widget class="QLabel" name="label">
+        <property name="font">
+         <font>
+          <pointsize>16</pointsize>
+         </font>
+        </property>
+        <property name="layoutDirection">
+         <enum>Qt::LeftToRight</enum>
+        </property>
+        <property name="text">
+         <string>AVAILABLE GAMES ON SERVER</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="label_8">
+        <property name="text">
+         <string>Total time played, seconds:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="label_9">
+        <property name="text">
+         <string>Total games played:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QLabel" name="averageDurationLabel">
+        <property name="text">
+         <string>0</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QLabel" name="averagePlayersLabel">
+        <property name="text">
+         <string>0</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QLabel" name="totalTimePlayedLabel">
+        <property name="text">
+         <string>0</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
+       <widget class="QLabel" name="totalGamesPlayedLabel">
+        <property name="text">
+         <string>0</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </widget>
   </widget>
   <widget class="QMenuBar" name="menubar">

--- a/client/views/startview.cpp
+++ b/client/views/startview.cpp
@@ -32,6 +32,9 @@ void StartView::on_cavokeTestWindowButton_clicked() {
 }
 
 void StartView::on_statisticsButton_clicked() {
+    if (!AuthDialog::verifyAuth(this)) {
+        return;
+    }
     this->close();
     emit shownStatisticsView();
 }

--- a/client/views/startview.cpp
+++ b/client/views/startview.cpp
@@ -31,6 +31,11 @@ void StartView::on_cavokeTestWindowButton_clicked() {
     emit shownTestWindowView();
 }
 
+void StartView::on_statisticsButton_clicked() {
+    this->close();
+    emit shownStatisticsView();
+}
+
 void StartView::on_settingsButton_clicked() {
     this->close();
     emit shownSettingsView();

--- a/client/views/startview.h
+++ b/client/views/startview.h
@@ -20,6 +20,7 @@ signals:
     void shownCreateGameView();
     void shownSettingsView();
     void shownGamesListView();
+    void shownStatisticsView();
     void clickedExitButton();
 
 private slots:
@@ -27,6 +28,7 @@ private slots:
     void on_createGameButton_clicked();
     void on_gamesListButton_clicked();
     void on_cavokeTestWindowButton_clicked();
+    void on_statisticsButton_clicked();
     void on_settingsButton_clicked();
     void on_exitButton_clicked();
 

--- a/client/views/startview.ui
+++ b/client/views/startview.ui
@@ -41,7 +41,7 @@
          <x>230</x>
          <y>160</y>
          <width>321</width>
-         <height>194</height>
+         <height>232</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -70,6 +70,13 @@
          <widget class="QPushButton" name="cavokeTestWindowButton">
           <property name="text">
            <string>Developer mode</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="statisticsButton">
+          <property name="text">
+           <string>Statistics</string>
           </property>
          </widget>
         </item>
@@ -103,7 +110,7 @@
              <string/>
             </property>
             <property name="icon">
-             <iconset resource="resources/resources.qrc">
+             <iconset>
               <normaloff>:/info</normaloff>:/info</iconset>
             </property>
            </widget>
@@ -160,7 +167,7 @@
            <string/>
           </property>
           <property name="pixmap">
-           <pixmap resource="resources/resources.qrc">:/cavoke</pixmap>
+           <pixmap>:/cavoke</pixmap>
           </property>
          </widget>
         </item>
@@ -197,7 +204,7 @@
      <x>0</x>
      <y>0</y>
      <width>800</width>
-     <height>19</height>
+     <height>28</height>
     </rect>
    </property>
   </widget>

--- a/client/views/statisticsview.cpp
+++ b/client/views/statisticsview.cpp
@@ -24,9 +24,12 @@ void StatisticsView::displayEmpty() {
     ui->win_rate_label->setText("0");
 }
 
-void StatisticsView::gotUserGameStatisticsUpdate(const UserGameStatistics &userGameStatistics) {
-    ui->time_played_label->setText(QString::number(userGameStatistics.time_played_sec));
-    ui->games_played_label->setText(QString::number(userGameStatistics.games_played));
+void StatisticsView::gotUserGameStatisticsUpdate(
+    const UserGameStatistics &userGameStatistics) {
+    ui->time_played_label->setText(
+        QString::number(userGameStatistics.time_played_sec));
+    ui->games_played_label->setText(
+        QString::number(userGameStatistics.games_played));
     ui->win_rate_label->setText(QString::number(userGameStatistics.win_rate));
 }
 
@@ -54,6 +57,13 @@ void StatisticsView::gotUserStatisticsUpdate(
         QString::number(userStatistics.total_games_played));
 }
 
-void StatisticsView::on_refreshButton_clicked() {
+void StatisticsView::requestUpdates() {
     emit requestedRefresh();
+    emit statisticsGameChanged(
+        ui->games_combobox->itemData(ui->games_combobox->currentIndex())
+            .toString());
+}
+
+void StatisticsView::on_refreshButton_clicked() {
+    requestUpdates();
 }

--- a/client/views/statisticsview.cpp
+++ b/client/views/statisticsview.cpp
@@ -17,6 +17,15 @@ void StatisticsView::on_backButton_clicked() {
     emit shownStartView();
 }
 
+void StatisticsView::gotGamesListUpdate(
+    const std::vector<GameInfo> &newGamesList) {
+    ui->games_combobox->clear();
+    for (const auto &gameInfo : newGamesList) {
+        ui->games_combobox->addItem(gameInfo.display_name);
+    }
+    //    ui->gamesListWidget->setCurrentIndex(-1); // Is needed? Tests required
+}
+
 //void StatisticsView::on_StatisticsButton_clicked() {
 //    QString inviteCode = ui->inviteCodeInput->text();
 //    // verify user is authenticated

--- a/client/views/statisticsview.cpp
+++ b/client/views/statisticsview.cpp
@@ -1,0 +1,29 @@
+#include "statisticsview.h"
+#include <QFileDialog>
+#include "authdialog.h"
+#include "ui_statisticsview.h"
+
+StatisticsView::StatisticsView(QWidget *parent)
+    : QMainWindow(parent), ui(new Ui::StatisticsView) {
+    ui->setupUi(this);
+}
+
+StatisticsView::~StatisticsView() {
+    delete ui;
+}
+
+void StatisticsView::on_backButton_clicked() {
+    this->close();
+    emit shownStartView();
+}
+
+//void StatisticsView::on_StatisticsButton_clicked() {
+//    QString inviteCode = ui->inviteCodeInput->text();
+//    // verify user is authenticated
+//    if (!AuthDialog::verifyAuth(this)) {
+//        return;
+//    }
+//    if (!inviteCode.isEmpty()) {
+//        emit joinedGame(inviteCode);
+//    }
+//}

--- a/client/views/statisticsview.cpp
+++ b/client/views/statisticsview.cpp
@@ -6,6 +6,28 @@
 StatisticsView::StatisticsView(QWidget *parent)
     : QMainWindow(parent), ui(new Ui::StatisticsView) {
     ui->setupUi(this);
+    connect(ui->games_combobox, SIGNAL(currentIndexChanged(int)), this,
+            SLOT(repeaterCurrentIndexChanged(int)));
+}
+
+void StatisticsView::repeaterCurrentIndexChanged(int index) {
+    if (index == -1) {
+        displayEmpty();
+        return;
+    }
+    emit statisticsGameChanged(ui->games_combobox->itemData(index).toString());
+}
+
+void StatisticsView::displayEmpty() {
+    ui->time_played_label->setText("0");
+    ui->games_played_label->setText("0");
+    ui->win_rate_label->setText("0");
+}
+
+void StatisticsView::gotUserGameStatisticsUpdate(const UserGameStatistics &userGameStatistics) {
+    ui->time_played_label->setText(QString::number(userGameStatistics.time_played_sec));
+    ui->games_played_label->setText(QString::number(userGameStatistics.games_played));
+    ui->win_rate_label->setText(QString::number(userGameStatistics.win_rate));
 }
 
 StatisticsView::~StatisticsView() {
@@ -21,18 +43,17 @@ void StatisticsView::gotGamesListUpdate(
     const std::vector<GameInfo> &newGamesList) {
     ui->games_combobox->clear();
     for (const auto &gameInfo : newGamesList) {
-        ui->games_combobox->addItem(gameInfo.display_name);
+        ui->games_combobox->addItem(gameInfo.display_name, gameInfo.id);
     }
-    //    ui->gamesListWidget->setCurrentIndex(-1); // Is needed? Tests required
+}
+void StatisticsView::gotUserStatisticsUpdate(
+    const UserStatistics &userStatistics) {
+    ui->total_time_played_label->setText(
+        QString::number(userStatistics.total_time_played_sec));
+    ui->total_games_played_label->setText(
+        QString::number(userStatistics.total_games_played));
 }
 
-//void StatisticsView::on_StatisticsButton_clicked() {
-//    QString inviteCode = ui->inviteCodeInput->text();
-//    // verify user is authenticated
-//    if (!AuthDialog::verifyAuth(this)) {
-//        return;
-//    }
-//    if (!inviteCode.isEmpty()) {
-//        emit joinedGame(inviteCode);
-//    }
-//}
+void StatisticsView::on_refreshButton_clicked() {
+    emit requestedRefresh();
+}

--- a/client/views/statisticsview.h
+++ b/client/views/statisticsview.h
@@ -21,6 +21,7 @@ public slots:
     void gotUserStatisticsUpdate(const UserStatistics &userStatistics);
     void gotUserGameStatisticsUpdate(
         const UserGameStatistics &userGameStatistics);
+    void requestUpdates();
 
 signals:
     void shownStartView();

--- a/client/views/statisticsview.h
+++ b/client/views/statisticsview.h
@@ -1,0 +1,28 @@
+#ifndef CAVOKE_CLIENT_STATISTICSVIEW_H
+#define CAVOKE_CLIENT_STATISTICSVIEW_H
+
+#include <QMainWindow>
+
+namespace Ui {
+class StatisticsView;
+}
+
+class StatisticsView : public QMainWindow {
+    Q_OBJECT
+public:
+    explicit StatisticsView(QWidget *parent = nullptr);
+    ~StatisticsView();
+
+signals:
+    void shownStartView();
+//    void joinedGame(const QString &inviteCode);
+
+private slots:
+    void on_backButton_clicked();
+//    void on_joinGameButton_clicked();
+
+private:
+    Ui::StatisticsView *ui;
+};
+
+#endif  // CAVOKE_CLIENT_STATISTICSVIEW_H

--- a/client/views/statisticsview.h
+++ b/client/views/statisticsview.h
@@ -2,6 +2,7 @@
 #define CAVOKE_CLIENT_STATISTICSVIEW_H
 
 #include <QMainWindow>
+#include "entities/gameinfo.h"
 
 namespace Ui {
 class StatisticsView;
@@ -12,6 +13,9 @@ class StatisticsView : public QMainWindow {
 public:
     explicit StatisticsView(QWidget *parent = nullptr);
     ~StatisticsView();
+
+public slots:
+    void gotGamesListUpdate(const std::vector<GameInfo> &newGamesList);
 
 signals:
     void shownStartView();

--- a/client/views/statisticsview.h
+++ b/client/views/statisticsview.h
@@ -3,6 +3,8 @@
 
 #include <QMainWindow>
 #include "entities/gameinfo.h"
+#include "entities/usergamestatistics.h"
+#include "entities/userstatistics.h"
 
 namespace Ui {
 class StatisticsView;
@@ -16,14 +18,20 @@ public:
 
 public slots:
     void gotGamesListUpdate(const std::vector<GameInfo> &newGamesList);
+    void gotUserStatisticsUpdate(const UserStatistics &userStatistics);
+    void gotUserGameStatisticsUpdate(
+        const UserGameStatistics &userGameStatistics);
 
 signals:
     void shownStartView();
-//    void joinedGame(const QString &inviteCode);
+    void requestedRefresh();
+    void statisticsGameChanged(const QString &gameId);
 
 private slots:
     void on_backButton_clicked();
-//    void on_joinGameButton_clicked();
+    void on_refreshButton_clicked();
+    void displayEmpty();
+    void repeaterCurrentIndexChanged(int index);
 
 private:
     Ui::StatisticsView *ui;

--- a/client/views/statisticsview.ui
+++ b/client/views/statisticsview.ui
@@ -60,15 +60,19 @@
        <height>481</height>
       </rect>
      </property>
-     <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,0,0,0,0" columnstretch="0,0">
+     <layout class="QGridLayout" name="gridLayout" rowstretch="4,1,1,1,1,1,1,3,0" columnstretch="2,3">
       <property name="leftMargin">
        <number>10</number>
       </property>
       <property name="rightMargin">
        <number>10</number>
       </property>
-      <item row="3" column="1">
-       <widget class="QComboBox" name="games_combobox"/>
+      <item row="6" column="1">
+       <widget class="QLabel" name="win_rate_label">
+        <property name="text">
+         <string>0</string>
+        </property>
+       </widget>
       </item>
       <item row="5" column="0">
        <widget class="QLabel" name="label_8">
@@ -77,10 +81,48 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="1">
-       <widget class="QLabel" name="time_played_label">
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_6">
+        <property name="text">
+         <string>Statistics for game:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_7">
+        <property name="text">
+         <string>Time played, seconds:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Total games played:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QLabel" name="games_played_label">
         <property name="text">
          <string>0</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLabel" name="total_time_played_label">
+        <property name="text">
+         <string>0</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QComboBox" name="games_combobox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Ignored" vsizetype="Ignored">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
         </property>
        </widget>
       </item>
@@ -102,10 +144,17 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_2">
+      <item row="2" column="1">
+       <widget class="QLabel" name="total_games_played_label">
         <property name="text">
-         <string>Total games played:</string>
+         <string>0</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QLabel" name="time_played_label">
+        <property name="text">
+         <string>0</string>
         </property>
        </widget>
       </item>
@@ -116,20 +165,6 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="1">
-       <widget class="QLabel" name="games_played_label">
-        <property name="text">
-         <string>0</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="1">
-       <widget class="QLabel" name="win_rate_label">
-        <property name="text">
-         <string>0</string>
-        </property>
-       </widget>
-      </item>
       <item row="6" column="0">
        <widget class="QLabel" name="label_9">
         <property name="text">
@@ -137,40 +172,34 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_6">
-        <property name="text">
-         <string>Statistics for game:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="label_7">
-        <property name="text">
-         <string>Time played:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QLabel" name="total_games_played_label">
-        <property name="text">
-         <string>0</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QLabel" name="total_time_played_label">
-        <property name="text">
-         <string>0</string>
-        </property>
-       </widget>
-      </item>
       <item row="7" column="0" colspan="2">
-       <widget class="QPushButton" name="refreshButton">
-        <property name="text">
-         <string>Refresh</string>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <property name="leftMargin">
+         <number>200</number>
         </property>
-       </widget>
+        <property name="topMargin">
+         <number>20</number>
+        </property>
+        <property name="rightMargin">
+         <number>200</number>
+        </property>
+        <property name="bottomMargin">
+         <number>20</number>
+        </property>
+        <item>
+         <widget class="QPushButton" name="refreshButton">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Ignored" vsizetype="Ignored">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Refresh</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>

--- a/client/views/statisticsview.ui
+++ b/client/views/statisticsview.ui
@@ -166,7 +166,7 @@
        </widget>
       </item>
       <item row="7" column="0" colspan="2">
-       <widget class="QPushButton" name="refresh_button">
+       <widget class="QPushButton" name="refreshButton">
         <property name="text">
          <string>Refresh</string>
         </property>

--- a/client/views/statisticsview.ui
+++ b/client/views/statisticsview.ui
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>StatisticsView</class>
+ <widget class="QMainWindow" name="StatisticsView">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>800</width>
+    <height>600</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>800</width>
+    <height>600</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>800</width>
+    <height>600</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Cavoke</string>
+  </property>
+  <widget class="QWidget" name="centralwidget">
+   <widget class="QGroupBox" name="groupBox">
+    <property name="geometry">
+     <rect>
+      <x>9</x>
+      <y>9</y>
+      <width>782</width>
+      <height>541</height>
+     </rect>
+    </property>
+    <property name="title">
+     <string/>
+    </property>
+    <widget class="QPushButton" name="backButton">
+     <property name="geometry">
+      <rect>
+       <x>1</x>
+       <y>4</y>
+       <width>61</width>
+       <height>31</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Back</string>
+     </property>
+    </widget>
+    <widget class="QWidget" name="gridLayoutWidget">
+     <property name="geometry">
+      <rect>
+       <x>59</x>
+       <y>29</y>
+       <width>661</width>
+       <height>481</height>
+      </rect>
+     </property>
+     <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,0,0,0,0" columnstretch="0,0">
+      <property name="leftMargin">
+       <number>10</number>
+      </property>
+      <property name="rightMargin">
+       <number>10</number>
+      </property>
+      <item row="3" column="1">
+       <widget class="QComboBox" name="games_combobox"/>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_8">
+        <property name="text">
+         <string>Games played:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QLabel" name="time_played_label">
+        <property name="text">
+         <string>0</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" colspan="2">
+       <widget class="QLabel" name="label">
+        <property name="font">
+         <font>
+          <pointsize>16</pointsize>
+         </font>
+        </property>
+        <property name="layoutDirection">
+         <enum>Qt::LeftToRight</enum>
+        </property>
+        <property name="text">
+         <string>STATISTICS</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Total games played:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Total tme played, seconds:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QLabel" name="games_played_label">
+        <property name="text">
+         <string>0</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QLabel" name="win_rate_label">
+        <property name="text">
+         <string>0</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="label_9">
+        <property name="text">
+         <string>Win rate:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_6">
+        <property name="text">
+         <string>Statistics for game:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_7">
+        <property name="text">
+         <string>Time played:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLabel" name="total_games_played_label">
+        <property name="text">
+         <string>0</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLabel" name="total_time_played_label">
+        <property name="text">
+         <string>0</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0" colspan="2">
+       <widget class="QPushButton" name="refresh_button">
+        <property name="text">
+         <string>Refresh</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </widget>
+  </widget>
+  <widget class="QMenuBar" name="menubar">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>800</width>
+     <height>28</height>
+    </rect>
+   </property>
+  </widget>
+  <widget class="QStatusBar" name="statusbar"/>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
Теперь статистика отображается на клиенте.

Добавлена новая вкладка -- статистика, на которой отображается общая статистика игрока и comboBox, в котором можно выбрать игру для просмотра статистики по конкретной игре

Переработан экран со списком всех игр, теперь он выглядит аналогично остальным экранам и содержит статистику о выбранной игре.

Соответствующие статистики запрашиваются каждый раз при смене выбранной игры и, по сути, никуда не запоминаются. Если это критично, то, в целом, можно исправить, но хз